### PR TITLE
feat: Add an explicit "Search" option in the UserSearch component

### DIFF
--- a/src/components/UserSearch.tsx
+++ b/src/components/UserSearch.tsx
@@ -26,33 +26,48 @@ interface UserSearchProps {
     size?: "small" | "medium";
 }
 
+type SearchOption =
+    | {
+          type: "uuid";
+          uuid: string;
+      }
+    | {
+          type: "free-text";
+          text: string;
+      };
+
 interface UserSearchOptions<Multiple extends boolean> {
     uuids: string[];
     filterOptions: AutocompleteProps<
-        string,
+        SearchOption,
         Multiple,
         true,
-        true
+        false
     >["filterOptions"];
     renderOption: AutocompleteProps<
-        string,
+        SearchOption,
         Multiple,
         true,
-        true
+        false
     >["renderOption"];
     getOptionLabel: AutocompleteProps<
-        string,
+        SearchOption,
         false,
         true,
-        true
+        false
     >["getOptionLabel"];
     isOptionEqualToValue: AutocompleteProps<
-        string,
+        SearchOption,
         Multiple,
         true,
-        true
+        false
     >["isOptionEqualToValue"];
-    renderTags: AutocompleteProps<string, Multiple, true, true>["renderTags"];
+    renderTags: AutocompleteProps<
+        SearchOption,
+        Multiple,
+        true,
+        false
+    >["renderTags"];
 }
 
 const useUserSearchOptions = <Multiple extends boolean = false>(
@@ -70,19 +85,31 @@ const useUserSearchOptions = <Multiple extends boolean = false>(
         uuids,
         filterOptions: (options, { inputValue }) => {
             const namesForOptions = options.map((option) => {
-                const uuid = option;
-                const name = uuidToUsername[uuid];
-                const names = knownAliases[uuid] ?? [];
-                if (!name) {
-                    return {
-                        names,
-                        option,
-                    };
+                switch (option.type) {
+                    case "free-text":
+                        // The names can be anything here as long as it won't get filtered out
+                        return { names: [option.text], option: option };
+                    case "uuid": {
+                        const name = uuidToUsername[option.uuid];
+                        const names = knownAliases[option.uuid] ?? [];
+                        if (!name) {
+                            return {
+                                names,
+                                option,
+                            };
+                        }
+                        return { names: [name, ...names], option };
+                    }
                 }
-                return { names: [name, ...names], option };
             });
 
-            return orderUUIDsByScore(
+            const uuidToOption = Object.fromEntries(
+                options
+                    .filter((option) => option.type === "uuid")
+                    .map((option) => [option.uuid, option]),
+            );
+
+            const orderedUUIDs = orderUUIDsByScore(
                 namesForOptions
                     .filter(({ names }) => {
                         return names.some((name) =>
@@ -91,51 +118,124 @@ const useUserSearchOptions = <Multiple extends boolean = false>(
                                 .includes(inputValue.toLowerCase()),
                         );
                     })
-                    .map(({ option }) => option),
+                    .map(({ option }) => {
+                        if (option.type === "uuid") return option.uuid;
+                        return null;
+                    })
+                    .filter((uuid) => uuid !== null),
                 currentUser ?? undefined,
+            );
+
+            const orderedOptions: SearchOption[] = orderedUUIDs.map(
+                (uuid) => uuidToOption[uuid],
+            );
+
+            return orderedOptions.concat(
+                inputValue.trim()
+                    ? [{ type: "free-text", text: inputValue.trim() }]
+                    : [],
             );
         },
         renderOption: (props, option) => {
+            // Render as "Search for {text}"
             const { key, ...optionProps } = props; // eslint-disable-line @typescript-eslint/no-unsafe-assignment
-            const uuid = option;
-            return (
-                <Stack
-                    component="li"
-                    key={key} // eslint-disable-line @typescript-eslint/no-unsafe-assignment
-                    direction="row"
-                    gap={2}
-                    alignItems="center"
-                    {...optionProps}
-                >
-                    <Avatar
-                        src={`https://crafatar.com/renders/head/${uuid}?overlay`}
-                        alt={`Player head of ${uuidToUsername[uuid] ?? "unknown"}`}
-                    />
-                    <Typography variant="body1">
-                        {uuidToUsername[uuid]}
-                    </Typography>
-                </Stack>
-            );
+            switch (option.type) {
+                case "free-text": {
+                    // If text is UUID -> render as regular user option
+                    const valueAsNormalizedUUID = normalizeUUID(option.text);
+                    if (valueAsNormalizedUUID) {
+                        return (
+                            <UserOption
+                                key={key} // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+                                uuid={valueAsNormalizedUUID}
+                                optionProps={optionProps}
+                            />
+                        );
+                    }
+
+                    return (
+                        <Stack
+                            component="li"
+                            key={key} // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+                            direction="row"
+                            gap={2}
+                            alignItems="center"
+                            {...optionProps}
+                        >
+                            {/* HACK: Use an avatar to get the same layout as the UserOption*/}
+                            <Avatar>
+                                <Search fontSize="large" />
+                            </Avatar>
+                            <Typography variant="body1">
+                                Search for &ldquo;{option.text}&rdquo;
+                            </Typography>
+                        </Stack>
+                    );
+                }
+                case "uuid":
+                    return (
+                        <UserOption
+                            key={key} // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+                            uuid={option.uuid}
+                            optionProps={optionProps}
+                        />
+                    );
+                default:
+                    option satisfies never;
+            }
+            option satisfies never;
         },
         getOptionLabel: (option) => {
-            return uuidToUsername[option] ?? option;
+            switch (option.type) {
+                case "uuid":
+                    return uuidToUsername[option.uuid] ?? option.uuid;
+                case "free-text":
+                    return uuidToUsername[option.text] ?? option.text;
+                default:
+                    option satisfies never;
+                    return "";
+            }
         },
         isOptionEqualToValue: (option, value) => {
-            return (
-                option === value ||
-                uuidToUsername[option]?.toLowerCase() === value.toLowerCase()
-            );
+            if (option.type === "free-text") {
+                // We never want the free-text search option at the bottom of the list to be highlighted
+                return false;
+            }
+
+            switch (value.type) {
+                case "uuid":
+                    return option.uuid === value.uuid;
+                case "free-text": {
+                    // If the value of the submitted free-text was a uuid -> compare it with the option's uuid
+                    const valueAsNormalizedUUID = normalizeUUID(value.text);
+                    if (valueAsNormalizedUUID) {
+                        return option.uuid === valueAsNormalizedUUID;
+                    }
+
+                    // The free-text value was submitted as a username. Compare it with the option's username
+                    return (
+                        uuidToUsername[option.uuid]?.toLowerCase() ===
+                        value.text.toLowerCase()
+                    );
+                }
+                default:
+                    value satisfies never;
+                    return false;
+            }
         },
         renderTags: (value, getTagProps) =>
-            value.map((option: string, index: number) => {
-                const uuid = option;
+            value.map((option: SearchOption, index: number) => {
+                if (option.type === "free-text") {
+                    return null;
+                }
+
                 const { key, ...tagProps } = getTagProps({ index });
                 return (
                     <Chip
                         key={key}
                         {...tagProps}
                         label={
-                            uuidToUsername[uuid] ?? (
+                            uuidToUsername[option.uuid] ?? (
                                 <Skeleton variant="text" width={60} />
                             )
                         }
@@ -146,14 +246,36 @@ const useUserSearchOptions = <Multiple extends boolean = false>(
                                 style={{
                                     backgroundColor: "rgba(0, 0, 0, 0)",
                                 }}
-                                src={`https://crafatar.com/renders/head/${uuid}?overlay`}
-                                alt={`Player head of ${uuidToUsername[uuid] ?? "unknown"}`}
+                                src={`https://crafatar.com/renders/head/${option.uuid}?overlay`}
+                                alt={`Player head of ${uuidToUsername[option.uuid] ?? "unknown"}`}
                             />
                         }
                     />
                 );
             }),
     };
+};
+
+const UserOption: React.FC<{
+    uuid: string;
+    optionProps: React.HTMLAttributes<HTMLLIElement>;
+}> = ({ uuid, optionProps }) => {
+    const username = useUUIDToUsername([uuid])[uuid];
+    return (
+        <Stack
+            component="li"
+            direction="row"
+            gap={2}
+            alignItems="center"
+            {...optionProps}
+        >
+            <Avatar
+                src={`https://crafatar.com/renders/head/${uuid}?overlay`}
+                alt={`Player head of ${username ?? "unknown"}`}
+            />
+            <Typography variant="body1">{username}</Typography>
+        </Stack>
+    );
 };
 
 export const UserSearch: React.FC<UserSearchProps> = ({
@@ -174,8 +296,7 @@ export const UserSearch: React.FC<UserSearchProps> = ({
 
     return (
         <Autocomplete
-            freeSolo
-            options={uuids}
+            options={uuids.map((uuid) => ({ type: "uuid" as const, uuid }))}
             fullWidth
             size={size}
             // TODO: Clear the input when the user selects an option
@@ -187,10 +308,13 @@ export const UserSearch: React.FC<UserSearchProps> = ({
             getOptionLabel={getOptionLabel}
             isOptionEqualToValue={isOptionEqualToValue}
             onChange={(_, value) => {
-                if (!value) return; // Ignore clearing the input
+                if (value.type === "uuid") {
+                    onSubmit(value.uuid);
+                    return;
+                }
 
                 // Allow UUIDs to be entered directly
-                const valueAsNormalizedUUID = normalizeUUID(value);
+                const valueAsNormalizedUUID = normalizeUUID(value.text);
                 if (valueAsNormalizedUUID) {
                     onSubmit(valueAsNormalizedUUID);
                     return;
@@ -198,7 +322,7 @@ export const UserSearch: React.FC<UserSearchProps> = ({
 
                 setLoading(true);
                 queryClient
-                    .fetchQuery(getUUIDQueryOptions(value, addKnownAlias))
+                    .fetchQuery(getUUIDQueryOptions(value.text, addKnownAlias))
                     .then(({ uuid }) => {
                         onSubmit(uuid);
                     })
@@ -252,7 +376,7 @@ export const UserMultiSelect: React.FC<UserMultiSelectProps> = ({
     const queryClient = useQueryClient();
     const { addKnownAlias } = useKnownAliases();
     const {
-        uuids: options,
+        uuids: allUUIDs,
         filterOptions,
         renderOption,
         getOptionLabel,
@@ -264,8 +388,7 @@ export const UserMultiSelect: React.FC<UserMultiSelectProps> = ({
     return (
         <Autocomplete
             multiple
-            freeSolo
-            options={options}
+            options={allUUIDs.map((uuid) => ({ type: "uuid" as const, uuid }))}
             fullWidth
             size={size}
             autoHighlight
@@ -274,20 +397,24 @@ export const UserMultiSelect: React.FC<UserMultiSelectProps> = ({
             getOptionLabel={getOptionLabel}
             isOptionEqualToValue={isOptionEqualToValue}
             renderTags={renderTags}
-            value={[...uuids]}
+            value={[...uuids.map((uuid) => ({ type: "uuid" as const, uuid }))]}
             onChange={(_, newValues) => {
                 setLoading(true);
                 Promise.allSettled(
                     newValues.map((value) => {
+                        if (value.type === "uuid") {
+                            return Promise.resolve(value.uuid);
+                        }
+
                         // Allow UUIDs to be entered directly
-                        const valueAsNormalizedUUID = normalizeUUID(value);
+                        const valueAsNormalizedUUID = normalizeUUID(value.text);
                         if (valueAsNormalizedUUID) {
                             return valueAsNormalizedUUID;
                         }
 
                         return queryClient
                             .fetchQuery(
-                                getUUIDQueryOptions(value, addKnownAlias),
+                                getUUIDQueryOptions(value.text, addKnownAlias),
                             )
                             .then(({ uuid }) => {
                                 return uuid;


### PR DESCRIPTION
There was an issue in the previous component with `autoHighlight`,
causing it to be impossible to search for a player's name if the name
matched another result. Since the other result was automatically
highlighted, it would navigate to that instead of searching for the new
name.

This fixes this issue by adding an explicit option at the bottom of the
list to search for the current value.
