### PR TITLE
chore: Remove `npm run dev`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
     "version": "0.0.0",
     "type": "module",
     "scripts": {
-        "dev": "vite",
         "dev:staging": "vite --mode proxy-staging",
         "dev:production": "vite --mode proxy-production",
         "tsc": "tsc -p tsconfig.app.json",


### PR DESCRIPTION
This isn't used as we don't have msw or similar set up. It was also
confusing the copilot coding agent, as it defaulted to running that
command, which had nothing working.
