### PR TITLE
chore: Bump react-compiler babel plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
                 "@tanstack/react-query-persist-client": "^5.71.1",
                 "@tanstack/react-router": "^1.114.32",
                 "@tanstack/zod-adapter": "^1.114.32",
-                "babel-plugin-react-compiler": "^19.0.0-beta-e993439-20250328",
+                "babel-plugin-react-compiler": "^19.1.0-rc.3",
                 "dayjs": "^1.11.13",
                 "react": "^19.1.0",
                 "react-dom": "^19.1.0",
@@ -3531,9 +3531,9 @@
             }
         },
         "node_modules/babel-plugin-react-compiler": {
-            "version": "19.0.0-beta-e993439-20250328",
-            "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-19.0.0-beta-e993439-20250328.tgz",
-            "integrity": "sha512-eq0lxXDicCNfhtIhm2L2nW2FyDcPMfuJTQG641ZWMWxEVqwmtUlAkWXC4o5C3vykhWMTsXmiJe7/hxXVUbV8ZA==",
+            "version": "19.1.0-rc.3",
+            "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-19.1.0-rc.3.tgz",
+            "integrity": "sha512-mjRn69WuTz4adL0bXGx8Rsyk1086zFJeKmes6aK0xPuK3aaXmDJdLHqwKKMrpm6KAI1MCoUK72d2VeqQbu8YIA==",
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.26.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "@tanstack/react-query-persist-client": "^5.71.1",
         "@tanstack/react-router": "^1.114.32",
         "@tanstack/zod-adapter": "^1.114.32",
-        "babel-plugin-react-compiler": "^19.0.0-beta-e993439-20250328",
+        "babel-plugin-react-compiler": "^19.1.0-rc.3",
         "dayjs": "^1.11.13",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",


### PR DESCRIPTION
`@vitejs/plugin-react` v5 says
```
Make sure to use a newer version of babel-plugin-react-compiler that
supports target option.
```

Not really sure what that means in practice, but bumping to the latest
version should surely be good enough :^)
