### PR TITLE
chore: Verbose false on pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,13 +15,13 @@ repos:
       rev: v1.59.0
       hooks:
           - id: oxlint
-            verbose: true
+            verbose: false
 
     - repo: https://github.com/oxc-project/mirrors-oxfmt
       rev: v0.42.0
       hooks:
           - id: oxfmt
-            verbose: true
+            verbose: false
 
     - repo: local
       hooks:


### PR DESCRIPTION
Don't need to see debug/timing output on successful runs
