### PR TITLE
test: Start MSW worker once per file instead of per test

### DIFF
--- a/src/test/msw-test.ts
+++ b/src/test/msw-test.ts
@@ -3,21 +3,6 @@ import { test as testBase } from "vitest";
 import { worker } from "#mocks/worker.ts";
 
 export const mswTest = testBase.extend({
-    worker: [
-        // oxlint-disable-next-line no-empty-pattern, react/rules-of-hooks
-        async ({}, use) => {
-            // Start the worker before the test.
-            await worker.start({ onUnhandledRequest: "error", quiet: true });
-
-            // Expose the worker object on the test's context.
-            await use(worker);
-
-            // Remove any request handlers added in individual test cases.
-            // This prevents them from affecting unrelated tests.
-            worker.resetHandlers();
-        },
-        {
-            auto: true,
-        },
-    ],
+    // oxlint-disable-next-line no-empty-pattern, react/rules-of-hooks
+    worker: [async ({}, use) => use(worker), { auto: true }],
 });

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,18 @@
-import { beforeEach } from "vitest";
+import { afterEach, beforeAll, beforeEach } from "vitest";
+
+import { worker } from "#mocks/worker.ts";
+
+// Start the MSW worker once per test file. Calling worker.start() per test adds
+// measurable overhead; resetting handlers between tests keeps them isolated.
+beforeAll(async () => {
+    await worker.start({ onUnhandledRequest: "error", quiet: true });
+});
 
 beforeEach(() => {
     // Ensure localstorage doesn't leak between tests
     localStorage.clear();
+});
+
+afterEach(() => {
+    worker.resetHandlers();
 });


### PR DESCRIPTION
## Summary
- Move \`worker.start()\` out of the per-test \`mswTest\` fixture and into a \`beforeAll\` in the existing per-file setup file (\`src/test/setup.ts\`).
- \`resetHandlers()\` still runs in \`afterEach\` so tests stay isolated.
- This matches the pattern in the [official MSW recipe for vitest browser mode](https://mswjs.io/docs/recipes/vitest-browser-mode) and removes one service-worker registration per test (~175 tests × 2 browsers).

Expected to shave noticeable time off the UI test run, most visibly on webkit (which runs with \`--no-file-parallelism\` in CI and sits on the critical path).

## Test plan
- [x] \`pnpm run test:unit\` — all 475 unit tests pass locally.
- [x] \`pnpm run lint:check\` and \`pnpm run tsc\` pass.
- [ ] CI UI tests pass on chromium and webkit.
- [ ] Compare webkit test step duration on this PR vs recent main runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)