### PR TITLE
ci: Shard UI tests across 3 parallel jobs per browser

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -58,6 +58,7 @@ jobs:
         strategy:
             matrix:
                 browser: [chromium, webkit]
+                shard: [1, 2, 3]
             fail-fast: false
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -74,4 +75,4 @@ jobs:
 
             - name: Test
               timeout-minutes: 10
-              run: pnpm run test:ui:${{ matrix.browser }}
+              run: pnpm run test:ui:${{ matrix.browser }} --shard=${{ matrix.shard }}/3


### PR DESCRIPTION
## Summary
- Add a \`shard\` axis (\`[1, 2, 3]\`) to the \`ui-tests\` matrix and pass \`--shard=N/3\` to Vitest.
- 11 UI test files are now split across 3 runners per browser (6 UI jobs total instead of 2).
- Side-steps webkit's single-job OOM constraint without touching \`--no-file-parallelism\`.

Current CI (main, baseline) has \`ui-tests (webkit)\` on the critical path at ~2m10s for the test step. With 3 shards, each webkit runner should finish in ~40–50s, cutting total CI wall time by roughly half.

Trade-off: 6 concurrent UI jobs instead of 2. No code or test changes required — Vitest's \`--shard\` natively splits test files.

## Test plan
- [ ] CI matrix expands to \`ui-tests (chromium, 1/2/3)\` and \`ui-tests (webkit, 1/2/3)\`.
- [ ] Each shard runs a distinct subset of the 11 UI test files; total test count across shards equals the pre-shard total.
- [ ] Compare per-shard webkit durations against the previous ~2m10s single-job run — aim for ~40–50s per shard.
- [ ] Re-run a couple of times to confirm webkit flakiness does not resurface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)