### PR TITLE
test: re-enable file parallelism on webkit UI tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "test:unit": "vitest run --project unit",
         "test:ui": "vitest run --project ui --browser.headless",
         "test:ui:chromium": "vitest run --project ui --browser.headless --browser=chromium",
-        "test:ui:webkit": "vitest run --project ui --browser.headless --browser=webkit --no-file-parallelism",
+        "test:ui:webkit": "vitest run --project ui --browser.headless --browser=webkit",
         "test:watch": "vitest",
         "test:watch:unit": "vitest --project unit",
         "test:watch:ui": "vitest --project ui",


### PR DESCRIPTION
We disabled file parallelism for webkit in c4c5f1b to avoid OOM
crashes, and later added sharding in cec23a6 but left the flag in
place. The two mechanisms address the same problem via opposite
structures, and keeping both leaves us with the worst of each: every
shard still runs its files through a single long-lived webkit page,
accumulating memory until SIGKILL, surfacing as "Browser connection
was closed while running tests" / "[birpc] rpc is closed" at the
boundary between files.

Vitest browser mode runs all files in a worker through one page, with
per-file iframes for isolation (vitest#9095). With parallelism off,
one worker owns the whole shard — webkit's content process leaks
monotonically across files and eventually gets OOM-killed (confirmed
by yury-s on microsoft/playwright#30428: exitCode=137 = SIGKILL under
memory pressure). With parallelism on, each worker owns fewer files,
so no single page lives long enough to cross the OOM threshold.

Now that sharding gives us machine-level isolation, the per-shard
parallelism restriction is redundant. Drop --no-file-parallelism so
webkit shards use multiple workers and each worker's page has a
bounded lifetime.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
