### PR TITLE
chore(dependabot): switch github-actions interval to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
     - package-ecosystem: "github-actions"
       directory: "/"
       schedule:
-          interval: "daily"
+          interval: "weekly"
       cooldown:
           default-days: 7
       commit-message:


### PR DESCRIPTION
## Summary
- Switch the `github-actions` ecosystem schedule from `daily` to `weekly` to match GitHub's recommended cadence; with the existing 7-day `cooldown.default-days` a daily schedule mostly produces no-op checks.

## Test plan
- [ ] Confirm Dependabot accepts the file (no validation error in the GitHub UI for dependabot.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)