### PR TITLE
ci: split webkit ui tests into 6 shards

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -57,8 +57,16 @@ jobs:
             options: --ipc=host
         strategy:
             matrix:
-                browser: [chromium, webkit]
-                shard: [1, 2, 3]
+                include:
+                    - { browser: chromium, shard: 1, total: 3 }
+                    - { browser: chromium, shard: 2, total: 3 }
+                    - { browser: chromium, shard: 3, total: 3 }
+                    - { browser: webkit, shard: 1, total: 6 }
+                    - { browser: webkit, shard: 2, total: 6 }
+                    - { browser: webkit, shard: 3, total: 6 }
+                    - { browser: webkit, shard: 4, total: 6 }
+                    - { browser: webkit, shard: 5, total: 6 }
+                    - { browser: webkit, shard: 6, total: 6 }
             fail-fast: false
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -75,4 +83,4 @@ jobs:
 
             - name: Test
               timeout-minutes: 10
-              run: pnpm run test:ui:${{ matrix.browser }} --shard=${{ matrix.shard }}/3
+              run: pnpm run test:ui:${{ matrix.browser }} --shard=${{ matrix.shard }}/${{ matrix.total }}


### PR DESCRIPTION
## Summary

Attempt to circumvent the intermittent webkit crashes we have been seeing in CI by halving the number of tests each webkit shard runs (3 → 6). Chromium stays at 3 shards since it is not affected.

Smaller shards mean each webkit job has fewer tests where the flaky crash can land, and a re-run only re-executes a smaller slice — making the pipeline more likely to go green on retry. The matrix switches to `include` so each browser can carry its own shard total.

## Test plan
- [ ] CI passes on this PR
- [ ] Verify both `chromium` shards (1–3) and `webkit` shards (1–6) appear in the matrix and run the right slice (`--shard=N/3` for chromium, `--shard=N/6` for webkit)