### PR TITLE
schemas: cover invalid wrappedSearch.year fallback

### DIFF
--- a/src/schemas/wrappedSearch.unit.test.ts
+++ b/src/schemas/wrappedSearch.unit.test.ts
@@ -20,4 +20,18 @@ describe("wrappedSearchSchema validation", () => {
             year: 2025,
         });
     });
+
+    test("invalid year -> fallback to default", () => {
+        const result = wrappedSearchSchema.parse({
+            year: "not-a-number",
+        });
+        expect(result.year).toBe(getWrappedYear());
+    });
+
+    test("year out of range -> fallback to default", () => {
+        const result = wrappedSearchSchema.parse({
+            year: 1999,
+        });
+        expect(result.year).toBe(getWrappedYear());
+    });
 });


### PR DESCRIPTION
## Summary
Mutation testing on the search schemas (removing each `.catch()` and re-running tests) showed every catch fired in at least one named "invalid X" test — except `wrappedSearch.year`, whose only failing-on-removal test was "no params -> all defaults". That left the invalid-input branch unverified.

Add two new tests so removing `.catch(currentWrappedYear)` deterministically fails:
- `invalid year -> fallback to default` (non-numeric input)
- `year out of range -> fallback to default` (year below `min(2025)`)

Verified that with the catch removed, both new tests fail; with it present, all 4 tests pass.

Useful in its own right, and a prerequisite for confidently bumping zod to 4.4 (#251) where the catch's role narrows to invalid-only (missing keys are handled by a new `.default()`).

## Test plan
- [x] `pnpm vitest run --project unit src/schemas/wrappedSearch.unit.test.ts` — 4 tests pass
- [x] Mutation check: removed catch, both new tests fail as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)