### PR TITLE
feat(session): Add session detail page

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -58,6 +58,7 @@ function useShownPlayer(): string | null {
 
     switch (currentMatch.routeId) {
         case "/session/$uuid":
+        case "/session/$uuid_/detail":
         case "/wrapped/$uuid": {
             return currentMatch.params.uuid;
         }

--- a/src/helpers/sessionDetail.ts
+++ b/src/helpers/sessionDetail.ts
@@ -1,0 +1,560 @@
+import type { History } from "#queries/history.ts";
+import type { StatsPIT } from "#queries/playerdata.ts";
+import type {
+    GameOutcome,
+    GameResult,
+    GameSegment,
+    Gamemode,
+} from "#queries/sessionAt.ts";
+import type { Session } from "#queries/sessions.ts";
+import { computeStat } from "#stats/index.ts";
+import { REAL_GAMEMODE_KEYS } from "#stats/keys.ts";
+import { computeStatProgression, nextCloseMilestone } from "#stats/progression.ts";
+import { bedwarsLevelFromExp } from "#stats/stars.ts";
+import { MS_PER_DAY, MS_PER_HOUR } from "#time.ts";
+
+// The five core modes broken out on the session detail page, sourced from the
+// canonical mode list so adding a mode doesn't require editing a second copy.
+export const GAMEMODES: readonly Gamemode[] = REAL_GAMEMODE_KEYS;
+
+export interface SessionAggregate {
+    readonly games: number;
+    readonly wins: number;
+    readonly losses: number;
+    readonly fk: number;
+    readonly fd: number;
+    readonly bb: number;
+    readonly bl: number;
+    readonly k: number;
+    readonly d: number;
+    readonly xp: number;
+    readonly stars: number;
+    readonly fkdr: number;
+    readonly lifetimeFkdr: number;
+    readonly winRate: number;
+    readonly lifetimeWR: number;
+    readonly elapsedMs: number;
+}
+
+const ratio = (numerator: number, denominator: number): number =>
+    denominator === 0 ? numerator : numerator / denominator;
+
+// The raw counter deltas between two point-in-time snapshots of one gamemode.
+interface StatDelta {
+    readonly games: number;
+    readonly wins: number;
+    readonly losses: number;
+    readonly fk: number;
+    readonly fd: number;
+    readonly bb: number;
+    readonly bl: number;
+    readonly k: number;
+    readonly d: number;
+}
+
+export const statDelta = (first: StatsPIT, last: StatsPIT): StatDelta => ({
+    games: last.gamesPlayed - first.gamesPlayed,
+    wins: last.wins - first.wins,
+    losses: last.losses - first.losses,
+    fk: last.finalKills - first.finalKills,
+    fd: last.finalDeaths - first.finalDeaths,
+    bb: last.bedsBroken - first.bedsBroken,
+    bl: last.bedsLost - first.bedsLost,
+    k: last.kills - first.kills,
+    d: last.deaths - first.deaths,
+});
+
+export const aggregate = (session: Session): SessionAggregate => {
+    const delta = statDelta(session.start.overall, session.end.overall);
+    const xp = session.end.experience - session.start.experience;
+    const stars =
+        bedwarsLevelFromExp(session.end.experience) -
+        bedwarsLevelFromExp(session.start.experience);
+    // Route the ratio stats through computeStat so the session detail page and
+    // the rest of the app share one ratio semantic. "session" measures the
+    // delta across [start, end]; "overall" reads the lifetime value at a point.
+    const history: History = [session.start, session.end];
+    return {
+        ...delta,
+        xp,
+        stars,
+        fkdr: computeStat(session.end, "overall", "fkdr", "session", history),
+        lifetimeFkdr: computeStat(session.start, "overall", "fkdr", "overall", history),
+        winRate: computeStat(session.end, "overall", "winrate", "session", history),
+        lifetimeWR: computeStat(
+            session.start,
+            "overall",
+            "winrate",
+            "overall",
+            history,
+        ),
+        elapsedMs: session.end.queriedAt.getTime() - session.start.queriedAt.getTime(),
+    };
+};
+
+export type SessionTagKey = "flawless" | "perfect" | "on_fire" | "marathon";
+
+/**
+ * Which auto-derived "badges" a session earns. `flawless` and `perfect` are
+ * mutually exclusive — flawless is the stronger claim (no losses *and* no final
+ * deaths), so it wins when both would apply.
+ */
+export const sessionTagKeys = (agg: SessionAggregate): SessionTagKey[] => {
+    const keys: SessionTagKey[] = [];
+
+    if (agg.games >= 2 && agg.losses === 0 && agg.fd === 0) {
+        keys.push("flawless");
+        // "Won every game" means exactly that: check wins against games rather
+        // than losses === 0, which would count a draw as a win.
+    } else if (agg.games >= 3 && agg.wins === agg.games) {
+        keys.push("perfect");
+    }
+
+    if (agg.fkdr > agg.lifetimeFkdr * 1.4 && agg.fk >= 6) {
+        keys.push("on_fire");
+    }
+
+    const hours = agg.elapsedMs / MS_PER_HOUR;
+    if (hours >= 3) {
+        keys.push("marathon");
+    }
+
+    return keys;
+};
+
+export type FkdrComparison = "beating" | "on_par" | "below";
+
+/**
+ * Classify the session FKDR against lifetime three ways: clearly above (≥ +10%)
+ * is "beating", clearly below (≤ −10%) is "below", and within ±10% is "on_par".
+ * A ±10% band keeps a session that merely matches lifetime from reading as a win
+ * or a loss.
+ */
+export const fkdrVsLifetime = (agg: SessionAggregate): FkdrComparison => {
+    let fkdrRatio: number;
+    if (agg.lifetimeFkdr > 0) {
+        fkdrRatio = agg.fkdr / agg.lifetimeFkdr;
+    } else {
+        fkdrRatio = agg.fkdr > 0 ? Infinity : 1;
+    }
+    if (fkdrRatio >= 1.1) return "beating";
+    if (fkdrRatio <= 0.9) return "below";
+    return "on_par";
+};
+
+export interface ModeStats {
+    readonly games: number;
+    readonly wins: number;
+    readonly losses: number;
+    readonly winRate: number;
+    readonly fk: number;
+    readonly fd: number;
+    readonly fkdr: number;
+    readonly bb: number;
+    readonly bl: number;
+    readonly k: number;
+    readonly d: number;
+    readonly kdr: number;
+}
+
+const ZERO_DELTA: StatDelta = {
+    games: 0,
+    wins: 0,
+    losses: 0,
+    fk: 0,
+    fd: 0,
+    bb: 0,
+    bl: 0,
+    k: 0,
+    d: 0,
+};
+
+const addDelta = (a: StatDelta, b: StatDelta): StatDelta => ({
+    games: a.games + b.games,
+    wins: a.wins + b.wins,
+    losses: a.losses + b.losses,
+    fk: a.fk + b.fk,
+    fd: a.fd + b.fd,
+    bb: a.bb + b.bb,
+    bl: a.bl + b.bl,
+    k: a.k + b.k,
+    d: a.d + b.d,
+});
+
+const subtractDelta = (a: StatDelta, b: StatDelta): StatDelta => ({
+    games: a.games - b.games,
+    wins: a.wins - b.wins,
+    losses: a.losses - b.losses,
+    fk: a.fk - b.fk,
+    fd: a.fd - b.fd,
+    bb: a.bb - b.bb,
+    bl: a.bl - b.bl,
+    k: a.k - b.k,
+    d: a.d - b.d,
+});
+
+const toModeStats = (de: StatDelta): ModeStats => ({
+    games: de.games,
+    wins: de.wins,
+    losses: de.losses,
+    winRate: ratio(de.wins, de.games),
+    fk: de.fk,
+    fd: de.fd,
+    fkdr: ratio(de.fk, de.fd),
+    bb: de.bb,
+    bl: de.bl,
+    k: de.k,
+    d: de.d,
+    kdr: ratio(de.k, de.d),
+});
+
+// The five core modes plus an "other" bucket for everything else (Dreams
+// modes) that the wire contract folds into `overall` but doesn't break out.
+export type ModeBreakdownKey = Gamemode | "other";
+
+export const modeBreakdown = (
+    session: Session,
+): Record<ModeBreakdownKey, ModeStats> => {
+    const out = {} as Record<ModeBreakdownKey, ModeStats>;
+    let core = ZERO_DELTA;
+    for (const mode of GAMEMODES) {
+        const delta = statDelta(session.start[mode], session.end[mode]);
+        out[mode] = toModeStats(delta);
+        core = addDelta(core, delta);
+    }
+    // Some players have strange stats where sum(gamemodes) != overall
+    // surface that here in case it happens.
+    const overall = statDelta(session.start.overall, session.end.overall);
+    out.other = toModeStats(subtractDelta(overall, core));
+    return out;
+};
+
+/**
+ * Count how many games happened in a segment with no derivable per-game
+ * stats. Returns 0 for a no-game window (no stats moved), N>=1 for a segment
+ * that covers N games we couldn't split (e.g. gamesPlayed jumped by 2).
+ *
+ * Uses `overall.gamesPlayed`, not the five core modes — games played in a
+ * non-core mode (a Dreams mode) move overall but leave solo/doubles/threes/
+ * fours/4v4 flat, so summing the five would miss them entirely.
+ */
+export const inferredGameCount = (seg: GameSegment): number =>
+    Math.max(0, seg.end.overall.gamesPlayed - seg.start.overall.gamesPlayed);
+
+export interface SegmentGameNumber {
+    /**
+     * 1-based number of the first game in this segment by running game count,
+     * or null for a no-game window (it advanced the count by zero, so it gets
+     * no game number).
+     */
+    readonly first: number | null;
+    /** Number of the last game — equal to `first` for a single game. */
+    readonly last: number | null;
+    /** Games this segment covers (0 for a no-game window). */
+    readonly count: number;
+}
+
+/**
+ * Number every segment by the running game count so the momentum strip,
+ * highlights and trajectory chart all agree on which game is which. A real
+ * single-game segment covers one game; a multi-game gap covers
+ * `inferredGameCount` games; a no-game window covers zero and gets no number.
+ */
+export const segmentGameNumbers = (
+    segments: readonly GameSegment[],
+): SegmentGameNumber[] => {
+    let gamesSoFar = 0;
+    return segments.map((seg) => {
+        const count = seg.game === null ? inferredGameCount(seg) : 1;
+        if (count === 0) {
+            return { first: null, last: null, count: 0 };
+        }
+        const first = gamesSoFar + 1;
+        gamesSoFar += count;
+        return { first, last: gamesSoFar, count };
+    });
+};
+
+/**
+ * Compact label for a segment's game number(s): `G3` for a single game,
+ * `G5-7` for a multi-game gap, or null for a no-game window.
+ */
+export const gameNumberLabel = (num: SegmentGameNumber): string | null => {
+    if (num.first === null || num.last === null) return null;
+    return num.first === num.last
+        ? `G${num.first.toString()}`
+        : `G${num.first.toString()}-${num.last.toString()}`;
+};
+
+export interface TrajectoryPoint {
+    /**
+     * X-axis label for the point: `G3` for a single game, `G5-7` for a
+     * multi-game gap spanning games 5 through 7.
+     */
+    readonly label: string;
+    readonly sessionFkdr: number;
+    readonly lifetimeFkdr: number;
+}
+
+/**
+ * Compute the FKDR trajectory: the cumulative session FKDR and the live
+ * lifetime FKDR after each game, numbered by the running game count rather
+ * than by segment index.
+ *
+ *  - A real single-game segment is one point, labelled `G{n}`.
+ *  - A multi-game gap (games we couldn't split apart) is one point spanning
+ *    the games it covers, labelled `G{first}-{last}`.
+ *  - A no-game window moves no finals, so it's dropped entirely rather than
+ *    drawn as a flat, misleadingly game-numbered point.
+ */
+export const fkdrTrajectory = (
+    session: Session,
+    segments: readonly GameSegment[],
+): TrajectoryPoint[] => {
+    const numbers = segmentGameNumbers(segments);
+    const points: TrajectoryPoint[] = [];
+    for (const [i, seg] of segments.entries()) {
+        const label = gameNumberLabel(numbers[i]);
+        if (label === null) {
+            // No-game window: FKDR is unchanged here, so it adds nothing.
+            continue;
+        }
+        points.push({
+            label,
+            sessionFkdr: computeStat(seg.end, "overall", "fkdr", "session", [
+                session.start,
+                seg.end,
+            ]),
+            lifetimeFkdr: computeStat(seg.end, "overall", "fkdr", "overall", [
+                session.start,
+                seg.end,
+            ]),
+        });
+    }
+    return points;
+};
+
+export interface Milestone {
+    readonly key: "prestige" | "wins" | "fkdr";
+    readonly label: string;
+    readonly current: number;
+    /** The next milestone value, or null when no progress was made this session. */
+    readonly target: number | null;
+    readonly format: (v: number) => string;
+    readonly deltaFormat: () => string;
+    /** How many sessions like this one to reach the target (∞ if not on pace). */
+    readonly sessions: number;
+    /** Projected playtime to reach the target, in ms (0 if not on pace). */
+    readonly playtimeMs: number;
+    /** Set when the target is unreachable at this session's pace. */
+    readonly blockedReason: string | null;
+}
+
+interface MilestoneSpec {
+    readonly key: Milestone["key"];
+    readonly label: string;
+    readonly stat: "stars" | "wins" | "fkdr";
+    readonly format: (v: number) => string;
+    readonly deltaFormat: () => string;
+    readonly currentFallback: number;
+}
+
+/**
+ * Milestones for the session, computed with the *same* projection helper the
+ * regular session page uses (`computeStatProgression`), so the milestone
+ * targets and ETAs always agree between the two pages.
+ *
+ * The trick: feed the session itself as the tracking interval. The pace is then
+ * "progress per session-worth of play", so `daysUntilMilestone` comes back as
+ * the projected playtime to reach the target — which divided by the session
+ * length is "X sessions like this".
+ */
+export const computeMilestones = (
+    session: Session,
+    agg: SessionAggregate,
+): Milestone[] => {
+    const history: History = [session.start, session.end];
+    const trackingEnd = session.end.queriedAt;
+    const sessionMs = agg.elapsedMs;
+    const last = session.end;
+
+    const specs: readonly MilestoneSpec[] = [
+        {
+            key: "prestige",
+            label: "Next stars milestone",
+            stat: "stars",
+            format: (v) => `✦${v.toFixed(0)}`,
+            deltaFormat: () => `+${agg.stars.toFixed(2)}/session`,
+            currentFallback: bedwarsLevelFromExp(last.experience),
+        },
+        {
+            key: "wins",
+            label: "Next wins milestone",
+            stat: "wins",
+            format: (v) => v.toLocaleString(),
+            deltaFormat: () => `+${agg.wins.toString()}/session`,
+            currentFallback: last.overall.wins,
+        },
+        {
+            key: "fkdr",
+            label: "Next FKDR milestone",
+            stat: "fkdr",
+            format: (v) => v.toFixed(2),
+            deltaFormat: () => `session: ${agg.fkdr.toFixed(2)}`,
+            currentFallback: ratio(last.overall.finalKills, last.overall.finalDeaths),
+        },
+    ];
+
+    return specs.map((spec): Milestone => {
+        const progression = computeStatProgression(
+            history,
+            trackingEnd,
+            spec.stat,
+            "overall",
+            // Closer, more reachable targets than the default — the session
+            // detail page wants goals that are only a session or two out.
+            nextCloseMilestone,
+        );
+        if (progression.error) {
+            return {
+                key: spec.key,
+                label: spec.label,
+                current: spec.currentFallback,
+                target: null,
+                format: spec.format,
+                deltaFormat: spec.deltaFormat,
+                sessions: Number.POSITIVE_INFINITY,
+                playtimeMs: 0,
+                blockedReason: "No progress this session",
+            };
+        }
+
+        const reachable = Number.isFinite(progression.daysUntilMilestone);
+        const playtimeMs = reachable ? progression.daysUntilMilestone * MS_PER_DAY : 0;
+        const sessions =
+            reachable && sessionMs > 0
+                ? playtimeMs / sessionMs
+                : Number.POSITIVE_INFINITY;
+        return {
+            key: spec.key,
+            label: spec.label,
+            current: progression.endValue,
+            target: progression.nextMilestoneValue,
+            format: spec.format,
+            deltaFormat: spec.deltaFormat,
+            sessions,
+            playtimeMs,
+            blockedReason: reachable ? null : "Not on pace to reach this",
+        };
+    });
+};
+
+export const segmentDurationMs = (seg: GameSegment): number =>
+    seg.end.queriedAt.getTime() - seg.start.queriedAt.getTime();
+
+export const segmentExperience = (seg: GameSegment): number =>
+    seg.end.experience - seg.start.experience;
+
+/**
+ * Best game = the single-game segment with the most final kills, breaking ties
+ * first toward no final death, then toward no bed lost. Ambiguous segments
+ * (no-game windows / multi-game gaps) are excluded.
+ */
+export const bestGame = (
+    segments: readonly GameSegment[],
+): (GameSegment & { game: GameResult }) | undefined => {
+    const games = segments.filter(
+        (seg): seg is GameSegment & { game: GameResult } => seg.game !== null,
+    );
+    const [best] = games.toSorted(
+        (a, b) =>
+            b.game.finalKills - a.game.finalKills ||
+            Number(a.game.finalDeath) - Number(b.game.finalDeath) ||
+            Number(a.game.bedLost) - Number(b.game.bedLost),
+    );
+    return best;
+};
+
+export const fastestWin = (
+    segments: readonly GameSegment[],
+): (GameSegment & { game: GameResult }) | undefined => {
+    const wins = segments.filter(
+        (seg): seg is GameSegment & { game: GameResult } =>
+            seg.game !== null && seg.game.outcome === "win",
+    );
+    let fastest: (GameSegment & { game: GameResult }) | undefined;
+    let fastestMs = Number.POSITIVE_INFINITY;
+    for (const seg of wins) {
+        const ms = segmentDurationMs(seg);
+        if (ms < fastestMs) {
+            fastest = seg;
+            fastestMs = ms;
+        }
+    }
+    return fastest;
+};
+
+/**
+ * Trailing streak of identical outcomes across single-game segments
+ * (ambiguous segments break the streak — we don't know individual
+ * outcomes). Returns null when no meaningful streak exists.
+ */
+export const trailingStreak = (
+    segments: readonly GameSegment[],
+): { length: number; outcome: GameOutcome } | null => {
+    let length = 0;
+    let outcome: GameOutcome | undefined;
+    for (let i = segments.length - 1; i >= 0; i--) {
+        const { game } = segments[i];
+        if (game === null) break;
+        if (outcome === undefined) {
+            ({ outcome } = game);
+            length = 1;
+            continue;
+        }
+        if (game.outcome === outcome) {
+            length++;
+        } else {
+            break;
+        }
+    }
+    if (length < 2 || outcome === undefined) return null;
+    return { length, outcome };
+};
+
+// Per-mode thresholds for a "perfect game": the maximum final kills and beds
+// broken available in a game of that mode. Hitting both means the player
+// single-handedly cleared the lobby.
+export const PERFECT_GAME_THRESHOLDS: Record<
+    Gamemode,
+    { finalKills: number; bedsBroken: number }
+> = {
+    solo: { finalKills: 7, bedsBroken: 7 },
+    doubles: { finalKills: 14, bedsBroken: 7 },
+    threes: { finalKills: 12, bedsBroken: 3 },
+    fours: { finalKills: 16, bedsBroken: 3 },
+    "4v4": { finalKills: 4, bedsBroken: 1 },
+};
+
+export const isPerfectGame = (game: GameResult): boolean => {
+    const thresholds = PERFECT_GAME_THRESHOLDS[game.gamemode];
+    return (
+        game.finalKills >= thresholds.finalKills &&
+        game.bedsBroken >= thresholds.bedsBroken
+    );
+};
+
+export type GameAccoladeKind = "perfect" | "carried" | "clutch";
+
+/**
+ * The notable thing about a won game, if any. Precedence is mutually exclusive:
+ * perfect > carried > clutch. Returns null for a loss/draw or an unremarkable
+ * win. The caller maps the kind to an icon/colour/label.
+ */
+export const gameAccolade = (game: GameResult): GameAccoladeKind | null => {
+    if (game.outcome !== "win") return null;
+    if (isPerfectGame(game)) return "perfect";
+    if (game.finalDeath) return "carried";
+    if (game.bedLost) return "clutch";
+    return null;
+};

--- a/src/helpers/sessionDetail.unit.test.ts
+++ b/src/helpers/sessionDetail.unit.test.ts
@@ -1,0 +1,1155 @@
+import { describe, expect, test } from "vitest";
+
+import type { PlayerDataPIT, StatsPIT } from "#queries/playerdata.ts";
+import type {
+    Gamemode,
+    GameOutcome,
+    GameResult,
+    GameSegment,
+} from "#queries/sessionAt.ts";
+import type { Session } from "#queries/sessions.ts";
+import { bedwarsLevelFromExp } from "#stats/stars.ts";
+
+import type { ModeStats, SessionAggregate } from "./sessionDetail.ts";
+import {
+    aggregate,
+    bestGame,
+    computeMilestones,
+    fastestWin,
+    fkdrTrajectory,
+    fkdrVsLifetime,
+    gameAccolade,
+    gameNumberLabel,
+    inferredGameCount,
+    isPerfectGame,
+    modeBreakdown,
+    segmentGameNumbers,
+    sessionTagKeys,
+    trailingStreak,
+} from "./sessionDetail.ts";
+
+const ZERO_STATS: StatsPIT = {
+    winstreak: 0,
+    gamesPlayed: 0,
+    wins: 0,
+    losses: 0,
+    bedsBroken: 0,
+    bedsLost: 0,
+    finalKills: 0,
+    finalDeaths: 0,
+    kills: 0,
+    deaths: 0,
+};
+
+const PLACEHOLDER_PIT: PlayerDataPIT = {
+    uuid: "00000000-0000-0000-0000-000000000000",
+    queriedAt: new Date(1_700_000_000_000),
+    experience: 0,
+    solo: ZERO_STATS,
+    doubles: ZERO_STATS,
+    threes: ZERO_STATS,
+    fours: ZERO_STATS,
+    "4v4": ZERO_STATS,
+    overall: ZERO_STATS,
+};
+
+const makeStats = (overrides: Partial<StatsPIT>): StatsPIT => ({
+    ...ZERO_STATS,
+    ...overrides,
+});
+
+const makePIT = (overrides: Partial<PlayerDataPIT>): PlayerDataPIT => ({
+    ...PLACEHOLDER_PIT,
+    ...overrides,
+});
+
+const makeSession = (start: PlayerDataPIT, end: PlayerDataPIT): Session => ({
+    start,
+    end,
+    extrapolated: false,
+    consecutive: true,
+    ongoing: false,
+});
+
+const makeGame = (overrides: Partial<GameResult>): GameResult => ({
+    gamemode: "fours",
+    outcome: "win",
+    finalKills: 0,
+    finalDeath: false,
+    bedsBroken: 0,
+    bedLost: false,
+    kills: 0,
+    deaths: 0,
+    experience: 0,
+    ...overrides,
+});
+
+const makeSegment = (
+    game: GameResult | null,
+    start: PlayerDataPIT = PLACEHOLDER_PIT,
+    end: PlayerDataPIT = PLACEHOLDER_PIT,
+): GameSegment => ({ start, end, game });
+
+describe(bestGame, () => {
+    const cases: {
+        name: string;
+        // null = an ambiguous (no-game / multi-game) segment
+        games: (Partial<GameResult> | null)[];
+        // index of the expected best segment, or null when none
+        expected: number | null;
+    }[] = [
+        { name: "no segments", games: [], expected: null },
+        { name: "only ambiguous segments", games: [null, null], expected: null },
+        { name: "single game", games: [{ finalKills: 3 }], expected: 0 },
+        {
+            name: "picks the most final kills",
+            games: [{ finalKills: 2 }, { finalKills: 5 }, { finalKills: 4 }],
+            expected: 1,
+        },
+        {
+            name: "skips ambiguous segments",
+            games: [{ finalKills: 5 }, null, { finalKills: 3 }],
+            expected: 0,
+        },
+        {
+            name: "final kills beat a cleaner game with fewer kills",
+            games: [
+                { finalKills: 6, finalDeath: true },
+                { finalKills: 5, finalDeath: false },
+            ],
+            expected: 0,
+        },
+        {
+            name: "tie on kills breaks toward no final death",
+            games: [
+                { finalKills: 5, finalDeath: true },
+                { finalKills: 5, finalDeath: false },
+            ],
+            expected: 1,
+        },
+        {
+            name: "tie on kills + final death breaks toward no bed lost",
+            games: [
+                { finalKills: 5, finalDeath: true, bedLost: true },
+                { finalKills: 5, finalDeath: true, bedLost: false },
+            ],
+            expected: 1,
+        },
+        {
+            name: "full tie keeps the earliest game",
+            games: [
+                { finalKills: 5, finalDeath: false, bedLost: false },
+                { finalKills: 5, finalDeath: false, bedLost: false },
+            ],
+            expected: 0,
+        },
+    ];
+
+    test.each(cases)("$name", ({ games, expected }) => {
+        const segments = games.map((game) =>
+            makeSegment(game === null ? null : makeGame(game)),
+        );
+        const result = bestGame(segments);
+        if (expected === null) {
+            expect(result).toBeUndefined();
+        } else {
+            expect(result).toBe(segments[expected]);
+        }
+    });
+});
+
+describe(fastestWin, () => {
+    // Each spec is [outcome | null (= gap), durationMinutes].
+    const segOf = ([outcome, mins]: readonly [
+        GameOutcome | null,
+        number,
+    ]): GameSegment =>
+        makeSegment(
+            outcome === null ? null : makeGame({ outcome }),
+            makePIT({ queriedAt: new Date(0) }),
+            makePIT({ queriedAt: new Date(mins * 60_000) }),
+        );
+
+    const cases: {
+        name: string;
+        segs: [GameOutcome | null, number][];
+        expected: number | null;
+    }[] = [
+        { name: "no segments", segs: [], expected: null },
+        {
+            name: "no wins",
+            segs: [
+                ["loss", 5],
+                [null, 3],
+            ],
+            expected: null,
+        },
+        {
+            name: "picks the shortest win",
+            segs: [
+                ["win", 10],
+                ["win", 4],
+                ["win", 7],
+            ],
+            expected: 1,
+        },
+        {
+            name: "ignores losses and gaps",
+            segs: [
+                ["loss", 1],
+                [null, 2],
+                ["win", 8],
+            ],
+            expected: 2,
+        },
+        {
+            name: "tie on duration keeps the earliest win",
+            segs: [
+                ["win", 5],
+                ["win", 5],
+            ],
+            expected: 0,
+        },
+    ];
+
+    test.each(cases)("$name", ({ segs, expected }) => {
+        const segments = segs.map(segOf);
+        const result = fastestWin(segments);
+        if (expected === null) {
+            expect(result).toBeUndefined();
+        } else {
+            expect(result).toBe(segments[expected]);
+        }
+    });
+});
+
+describe(trailingStreak, () => {
+    const cases: {
+        name: string;
+        // null = an ambiguous segment (breaks the streak)
+        outcomes: (GameOutcome | null)[];
+        expected: { length: number; outcome: GameOutcome } | null;
+    }[] = [
+        { name: "empty", outcomes: [], expected: null },
+        { name: "single game is not a streak", outcomes: ["win"], expected: null },
+        {
+            name: "two trailing wins",
+            outcomes: ["win", "win"],
+            expected: { length: 2, outcome: "win" },
+        },
+        {
+            name: "counts only the trailing run",
+            outcomes: ["loss", "win", "win", "win"],
+            expected: { length: 3, outcome: "win" },
+        },
+        {
+            name: "an opposite result breaks the streak",
+            outcomes: ["win", "loss", "win"],
+            expected: null,
+        },
+        {
+            name: "a gap breaks the streak",
+            outcomes: ["win", null, "win", "win"],
+            expected: { length: 2, outcome: "win" },
+        },
+        {
+            name: "a trailing gap means no streak",
+            outcomes: ["win", "win", null],
+            expected: null,
+        },
+        {
+            name: "all losses",
+            outcomes: ["loss", "loss", "loss"],
+            expected: { length: 3, outcome: "loss" },
+        },
+        {
+            name: "draws form a streak internally",
+            outcomes: ["draw", "draw"],
+            expected: { length: 2, outcome: "draw" },
+        },
+    ];
+
+    test.each(cases)("$name", ({ outcomes, expected }) => {
+        const segments = outcomes.map((outcome) =>
+            makeSegment(outcome === null ? null : makeGame({ outcome })),
+        );
+        expect(trailingStreak(segments)).toStrictEqual(expected);
+    });
+});
+
+describe(inferredGameCount, () => {
+    // The count must come from `overall`, not the core modes — games in a
+    // non-core mode (a Dreams mode) move overall but leave the core modes flat.
+    const pit = (
+        overall: number,
+        core: Partial<Record<Gamemode, number>> = {},
+    ): PlayerDataPIT =>
+        makePIT({
+            overall: makeStats({ gamesPlayed: overall }),
+            solo: makeStats({ gamesPlayed: core.solo ?? 0 }),
+            doubles: makeStats({ gamesPlayed: core.doubles ?? 0 }),
+            threes: makeStats({ gamesPlayed: core.threes ?? 0 }),
+            fours: makeStats({ gamesPlayed: core.fours ?? 0 }),
+        });
+
+    const cases: {
+        name: string;
+        start: { overall: number; core?: Partial<Record<Gamemode, number>> };
+        end: { overall: number; core?: Partial<Record<Gamemode, number>> };
+        expected: number;
+    }[] = [
+        {
+            name: "no games played",
+            start: { overall: 0 },
+            end: { overall: 0 },
+            expected: 0,
+        },
+        {
+            name: "a single game",
+            start: { overall: 10 },
+            end: { overall: 11 },
+            expected: 1,
+        },
+        {
+            name: "a multi-game jump",
+            start: { overall: 10 },
+            end: { overall: 12 },
+            expected: 2,
+        },
+        {
+            name: "counts non-core games where the core modes stay flat",
+            start: { overall: 25_234, core: {} },
+            end: { overall: 25_236, core: {} },
+            expected: 2,
+        },
+        {
+            name: "ignores a decrease",
+            start: { overall: 5 },
+            end: { overall: 3 },
+            expected: 0,
+        },
+    ];
+
+    test.each(cases)("$name", ({ start, end, expected }) => {
+        const segment = makeSegment(
+            null,
+            pit(start.overall, start.core),
+            pit(end.overall, end.core),
+        );
+        expect(inferredGameCount(segment)).toBe(expected);
+    });
+});
+
+describe(aggregate, () => {
+    test("computes deltas, ratios, xp, stars and elapsed time", () => {
+        const start = makePIT({
+            experience: 1_000_000,
+            queriedAt: new Date(1_700_000_000_000),
+            overall: makeStats({
+                gamesPlayed: 100,
+                wins: 60,
+                losses: 40,
+                finalKills: 200,
+                finalDeaths: 50,
+                bedsBroken: 80,
+                bedsLost: 30,
+                kills: 500,
+                deaths: 300,
+            }),
+        });
+        const end = makePIT({
+            experience: 1_100_000,
+            queriedAt: new Date(1_700_000_000_000 + 3_600_000),
+            overall: makeStats({
+                gamesPlayed: 110,
+                wins: 66,
+                losses: 44,
+                finalKills: 230,
+                finalDeaths: 60,
+                bedsBroken: 90,
+                bedsLost: 35,
+                kills: 560,
+                deaths: 330,
+            }),
+        });
+
+        expect(aggregate(makeSession(start, end))).toStrictEqual({
+            games: 10,
+            wins: 6,
+            losses: 4,
+            fk: 30,
+            fd: 10,
+            bb: 10,
+            bl: 5,
+            k: 60,
+            d: 30,
+            xp: 100_000,
+            stars: bedwarsLevelFromExp(1_100_000) - bedwarsLevelFromExp(1_000_000),
+            fkdr: 3,
+            lifetimeFkdr: 4,
+            winRate: 0.6,
+            lifetimeWR: 0.6,
+            elapsedMs: 3_600_000,
+        });
+    });
+
+    test("ratios fall back to the numerator when the denominator is zero", () => {
+        const start = makePIT({ overall: ZERO_STATS });
+        const end = makePIT({
+            overall: makeStats({
+                gamesPlayed: 5,
+                wins: 5,
+                finalKills: 12,
+                finalDeaths: 0,
+            }),
+        });
+
+        const result = aggregate(makeSession(start, end));
+        // No final deaths this session -> FKDR is just the final kills.
+        expect(result.fkdr).toBe(12);
+        // No lifetime games yet -> lifetime ratios are their numerators (0).
+        expect(result.lifetimeFkdr).toBe(0);
+        expect(result.lifetimeWR).toBe(0);
+        expect(result.winRate).toBe(1);
+    });
+});
+
+describe(modeBreakdown, () => {
+    const ZERO_MODE: ModeStats = {
+        games: 0,
+        wins: 0,
+        losses: 0,
+        winRate: 0,
+        fk: 0,
+        fd: 0,
+        fkdr: 0,
+        bb: 0,
+        bl: 0,
+        k: 0,
+        d: 0,
+        kdr: 0,
+    };
+
+    test("computes per-mode deltas and ratios, leaving unplayed modes at zero", () => {
+        const start = makePIT({
+            // overall must cover the core modes (here: just doubles' 10 games).
+            overall: makeStats({
+                gamesPlayed: 10,
+                wins: 6,
+                losses: 4,
+                finalKills: 20,
+                finalDeaths: 10,
+                bedsBroken: 8,
+                bedsLost: 3,
+                kills: 50,
+                deaths: 30,
+            }),
+            doubles: makeStats({
+                gamesPlayed: 10,
+                wins: 6,
+                losses: 4,
+                finalKills: 20,
+                finalDeaths: 10,
+                bedsBroken: 8,
+                bedsLost: 3,
+                kills: 50,
+                deaths: 30,
+            }),
+        });
+        const end = makePIT({
+            // overall delta = doubles delta + threes delta exactly -> no "other".
+            overall: makeStats({
+                gamesPlayed: 13,
+                wins: 8,
+                losses: 5,
+                finalKills: 31,
+                finalDeaths: 12,
+                bedsBroken: 10,
+                bedsLost: 4,
+                kills: 60,
+                deaths: 33,
+            }),
+            doubles: makeStats({
+                gamesPlayed: 12,
+                wins: 7,
+                losses: 5,
+                finalKills: 26,
+                finalDeaths: 12,
+                bedsBroken: 10,
+                bedsLost: 4,
+                kills: 60,
+                deaths: 33,
+            }),
+            // No final deaths in threes -> FKDR falls back to final kills.
+            threes: makeStats({
+                gamesPlayed: 1,
+                wins: 1,
+                finalKills: 5,
+                finalDeaths: 0,
+            }),
+        });
+
+        const data = modeBreakdown(makeSession(start, end));
+
+        expect(data.doubles).toStrictEqual({
+            games: 2,
+            wins: 1,
+            losses: 1,
+            winRate: 0.5,
+            fk: 6,
+            fd: 2,
+            fkdr: 3,
+            bb: 2,
+            bl: 1,
+            k: 10,
+            d: 3,
+            kdr: 10 / 3,
+        });
+        expect(data.threes).toStrictEqual({
+            games: 1,
+            wins: 1,
+            losses: 0,
+            winRate: 1,
+            fk: 5,
+            fd: 0,
+            fkdr: 5,
+            bb: 0,
+            bl: 0,
+            k: 0,
+            d: 0,
+            kdr: 0,
+        });
+        expect(data.solo).toStrictEqual(ZERO_MODE);
+        expect(data.fours).toStrictEqual(ZERO_MODE);
+        expect(data["4v4"]).toStrictEqual(ZERO_MODE);
+        // overall delta exactly equals the core modes -> nothing left over.
+        expect(data.other).toStrictEqual(ZERO_MODE);
+    });
+
+    test("attributes overall games not in the core modes to the other bucket", () => {
+        const start = makePIT({ overall: ZERO_STATS });
+        const end = makePIT({
+            // 2 wins / +715 xp worth of games, none of them in a core mode —
+            // the core modes stay flat, overall moves. Mirrors the prod session.
+            overall: makeStats({ gamesPlayed: 2, wins: 2, losses: 0 }),
+        });
+
+        const data = modeBreakdown(makeSession(start, end));
+
+        expect(data.solo).toStrictEqual(ZERO_MODE);
+        expect(data.doubles).toStrictEqual(ZERO_MODE);
+        expect(data.threes).toStrictEqual(ZERO_MODE);
+        expect(data.fours).toStrictEqual(ZERO_MODE);
+        expect(data["4v4"]).toStrictEqual(ZERO_MODE);
+        expect(data.other).toStrictEqual({
+            games: 2,
+            wins: 2,
+            losses: 0,
+            winRate: 1,
+            fk: 0,
+            fd: 0,
+            fkdr: 0,
+            bb: 0,
+            bl: 0,
+            k: 0,
+            d: 0,
+            kdr: 0,
+        });
+    });
+
+    test("gives 4v4 its own tile instead of the other bucket", () => {
+        const start = makePIT({ overall: ZERO_STATS });
+        const end = makePIT({
+            // A 4v4-only session: overall and 4v4 move in lockstep, so the
+            // whole delta is attributed to 4v4 and nothing is left over.
+            overall: makeStats({
+                gamesPlayed: 3,
+                wins: 2,
+                losses: 1,
+                finalKills: 6,
+                finalDeaths: 2,
+                bedsBroken: 2,
+                bedsLost: 1,
+                kills: 9,
+                deaths: 3,
+            }),
+            "4v4": makeStats({
+                gamesPlayed: 3,
+                wins: 2,
+                losses: 1,
+                finalKills: 6,
+                finalDeaths: 2,
+                bedsBroken: 2,
+                bedsLost: 1,
+                kills: 9,
+                deaths: 3,
+            }),
+        });
+
+        const data = modeBreakdown(makeSession(start, end));
+
+        expect(data["4v4"]).toStrictEqual({
+            games: 3,
+            wins: 2,
+            losses: 1,
+            winRate: 2 / 3,
+            fk: 6,
+            fd: 2,
+            fkdr: 3,
+            bb: 2,
+            bl: 1,
+            k: 9,
+            d: 3,
+            kdr: 3,
+        });
+        expect(data.solo).toStrictEqual(ZERO_MODE);
+        expect(data.doubles).toStrictEqual(ZERO_MODE);
+        expect(data.threes).toStrictEqual(ZERO_MODE);
+        expect(data.fours).toStrictEqual(ZERO_MODE);
+        expect(data.other).toStrictEqual(ZERO_MODE);
+    });
+});
+
+describe(fkdrTrajectory, () => {
+    const start = makePIT({
+        overall: makeStats({ finalKills: 10, finalDeaths: 5 }),
+    });
+    const session = makeSession(start, PLACEHOLDER_PIT);
+
+    // A real single-game segment ending at the given overall finals.
+    const realSeg = (finalKills: number, finalDeaths: number): GameSegment =>
+        makeSegment(
+            makeGame({}),
+            PLACEHOLDER_PIT,
+            makePIT({ overall: makeStats({ finalKills, finalDeaths }) }),
+        );
+
+    // A gap segment (no attributable per-game stats) covering
+    // `endGames - startGames` games.
+    const gapSeg = (
+        startGames: number,
+        endGames: number,
+        finalKills: number,
+        finalDeaths: number,
+    ): GameSegment =>
+        makeSegment(
+            null,
+            makePIT({ overall: makeStats({ gamesPlayed: startGames }) }),
+            makePIT({
+                overall: makeStats({ gamesPlayed: endGames, finalKills, finalDeaths }),
+            }),
+        );
+
+    test("returns no points for an empty session", () => {
+        expect(fkdrTrajectory(session, [])).toStrictEqual([]);
+    });
+
+    test("numbers real games sequentially and tracks session vs lifetime FKDR", () => {
+        const segments = [
+            realSeg(20, 10), // session (10/5)=2,  lifetime (20/10)=2
+            realSeg(40, 10), // session (30/5)=6,  lifetime (40/10)=4
+            realSeg(15, 5), // session (5/0)=5 (no deaths), lifetime (15/5)=3
+        ];
+
+        expect(fkdrTrajectory(session, segments)).toStrictEqual([
+            { label: "G1", sessionFkdr: 2, lifetimeFkdr: 2 },
+            { label: "G2", sessionFkdr: 6, lifetimeFkdr: 4 },
+            { label: "G3", sessionFkdr: 5, lifetimeFkdr: 3 },
+        ]);
+    });
+
+    test("labels a multi-game gap with the range of games it spans", () => {
+        const segments = [
+            realSeg(20, 10), // G1
+            gapSeg(100, 103, 50, 20), // 3 games -> G2-4
+        ];
+
+        expect(fkdrTrajectory(session, segments)).toStrictEqual([
+            { label: "G1", sessionFkdr: 2, lifetimeFkdr: 2 },
+            { label: "G2-4", sessionFkdr: 40 / 15, lifetimeFkdr: 2.5 },
+        ]);
+    });
+
+    test("drops no-game windows and keeps the numbering across them", () => {
+        const segments = [
+            realSeg(20, 10), // G1
+            gapSeg(100, 100, 30, 12), // no games played -> excluded
+            realSeg(40, 10), // G2 (the dropped window didn't advance the count)
+        ];
+
+        expect(fkdrTrajectory(session, segments)).toStrictEqual([
+            { label: "G1", sessionFkdr: 2, lifetimeFkdr: 2 },
+            { label: "G2", sessionFkdr: 6, lifetimeFkdr: 4 },
+        ]);
+    });
+});
+
+describe(segmentGameNumbers, () => {
+    const real = (): GameSegment => makeSegment(makeGame({}));
+    // A gap covering `games` games (0 => a no-game window).
+    const gap = (games: number): GameSegment =>
+        makeSegment(
+            null,
+            makePIT({ overall: makeStats({ gamesPlayed: 0 }) }),
+            makePIT({ overall: makeStats({ gamesPlayed: games }) }),
+        );
+
+    test("returns nothing for an empty session", () => {
+        expect(segmentGameNumbers([])).toStrictEqual([]);
+    });
+
+    test("numbers consecutive real games sequentially", () => {
+        expect(segmentGameNumbers([real(), real(), real()])).toStrictEqual([
+            { first: 1, last: 1, count: 1 },
+            { first: 2, last: 2, count: 1 },
+            { first: 3, last: 3, count: 1 },
+        ]);
+    });
+
+    test("a no-game window has no number and doesn't advance the count", () => {
+        expect(segmentGameNumbers([real(), gap(0), real()])).toStrictEqual([
+            { first: 1, last: 1, count: 1 },
+            { first: null, last: null, count: 0 },
+            { first: 2, last: 2, count: 1 },
+        ]);
+    });
+
+    test("a multi-game gap spans the range of games it covers", () => {
+        expect(segmentGameNumbers([real(), gap(3), real()])).toStrictEqual([
+            { first: 1, last: 1, count: 1 },
+            { first: 2, last: 4, count: 3 },
+            { first: 5, last: 5, count: 1 },
+        ]);
+    });
+
+    test("a single unattributable game still gets one number", () => {
+        expect(segmentGameNumbers([gap(1), real()])).toStrictEqual([
+            { first: 1, last: 1, count: 1 },
+            { first: 2, last: 2, count: 1 },
+        ]);
+    });
+});
+
+describe(gameNumberLabel, () => {
+    const cases: {
+        name: string;
+        num: { first: number | null; last: number | null; count: number };
+        expected: string | null;
+    }[] = [
+        { name: "single game", num: { first: 3, last: 3, count: 1 }, expected: "G3" },
+        {
+            name: "multi-game gap",
+            num: { first: 5, last: 7, count: 3 },
+            expected: "G5-7",
+        },
+        {
+            name: "no-game window",
+            num: { first: null, last: null, count: 0 },
+            expected: null,
+        },
+    ];
+
+    test.each(cases)("$name", ({ num, expected }) => {
+        expect(gameNumberLabel(num)).toBe(expected);
+    });
+});
+
+describe(computeMilestones, () => {
+    const HOUR_MS = 60 * 60 * 1000;
+    const T0 = 1_700_000_000_000;
+
+    // A one-hour session with progress on every tracked stat, so all three
+    // milestones are reachable.
+    const progressingSession = (): Session => {
+        const start = makePIT({
+            queriedAt: new Date(T0),
+            experience: 1_000_000,
+            overall: makeStats({
+                gamesPlayed: 500,
+                wins: 300,
+                losses: 200,
+                finalKills: 750,
+                finalDeaths: 250,
+            }),
+        });
+        const end = makePIT({
+            queriedAt: new Date(T0 + HOUR_MS),
+            experience: 1_100_000,
+            overall: makeStats({
+                gamesPlayed: 520,
+                wins: 315,
+                losses: 205,
+                finalKills: 810,
+                finalDeaths: 260,
+            }),
+        });
+        return makeSession(start, end);
+    };
+
+    const milestonesByKey = (session: Session) => {
+        const agg = aggregate(session);
+        const milestones = computeMilestones(session, agg);
+        return {
+            agg,
+            milestones,
+            prestige: milestones.find((m) => m.key === "prestige"),
+            wins: milestones.find((m) => m.key === "wins"),
+            fkdr: milestones.find((m) => m.key === "fkdr"),
+        };
+    };
+
+    test("returns the prestige, wins and fkdr milestones in order", () => {
+        const session = progressingSession();
+        const milestones = computeMilestones(session, aggregate(session));
+
+        expect(milestones.map((m) => m.key)).toStrictEqual([
+            "prestige",
+            "wins",
+            "fkdr",
+        ]);
+        expect(milestones.map((m) => m.label)).toStrictEqual([
+            "Next stars milestone",
+            "Next wins milestone",
+            "Next FKDR milestone",
+        ]);
+    });
+
+    test("projects a reachable counter milestone with finite pace", () => {
+        const { wins, agg } = milestonesByKey(progressingSession());
+
+        // +15 wins in the hour -> next half-decade above 315 is 350.
+        expect(wins?.current).toBe(315);
+        expect(wins?.target).toBe(350);
+        expect(wins?.blockedReason).toBeNull();
+        // (350-315) at 15 wins/session -> 2h20m of play.
+        expect(wins?.playtimeMs).toBeCloseTo(8_400_000);
+        expect(Number.isFinite(wins?.sessions ?? Infinity)).toBe(true);
+        // `sessions` is the projected playtime measured in session-lengths.
+        expect((wins?.sessions ?? 0) * agg.elapsedMs).toBeCloseTo(
+            wins?.playtimeMs ?? 0,
+        );
+        expect(wins?.deltaFormat()).toBe("+15/session");
+    });
+
+    test("projects the fkdr milestone from the session's kill ratio", () => {
+        const { fkdr } = milestonesByKey(progressingSession());
+
+        // End fkdr 810/260 ≈ 3.115; next 0.5 step up is 3.5.
+        expect(fkdr?.current).toBeCloseTo(810 / 260);
+        expect(fkdr?.target).toBe(3.5);
+        expect(fkdr?.blockedReason).toBeNull();
+        expect(fkdr?.playtimeMs).toBeCloseTo(14_400_000);
+        expect(fkdr?.sessions).toBeCloseTo(4);
+    });
+
+    test("reports the prestige milestone from experience gained", () => {
+        const session = progressingSession();
+        const { prestige } = milestonesByKey(session);
+        const endStars = bedwarsLevelFromExp(session.end.experience);
+
+        expect(prestige?.current).toBeCloseTo(endStars);
+        // Next multiple of ten (a tenth of a prestige) above the current stars.
+        expect(prestige?.target).toBe((Math.floor(endStars / 10) + 1) * 10);
+        expect(prestige?.blockedReason).toBeNull();
+        expect(Number.isFinite(prestige?.sessions ?? Infinity)).toBe(true);
+        expect(prestige?.playtimeMs ?? 0).toBeGreaterThan(0);
+    });
+
+    test("blocks a counter milestone when no progress was made on it", () => {
+        // Wins stay flat while finals climb: the wins milestone has no pace.
+        const start = makePIT({
+            queriedAt: new Date(T0),
+            experience: 1_000_000,
+            overall: makeStats({
+                gamesPlayed: 500,
+                wins: 300,
+                losses: 200,
+                finalKills: 750,
+                finalDeaths: 250,
+            }),
+        });
+        const end = makePIT({
+            queriedAt: new Date(T0 + HOUR_MS),
+            experience: 1_050_000,
+            overall: makeStats({
+                gamesPlayed: 510,
+                wins: 300, // unchanged
+                losses: 210,
+                finalKills: 800,
+                finalDeaths: 260,
+            }),
+        });
+
+        const { wins } = milestonesByKey(makeSession(start, end));
+
+        expect(wins?.target).toBeNull();
+        expect(wins?.sessions).toBe(Number.POSITIVE_INFINITY);
+        expect(wins?.playtimeMs).toBe(0);
+        expect(wins?.blockedReason).toBe("No progress this session");
+        // Falls back to the raw end-of-session count when there's no projection.
+        expect(wins?.current).toBe(300);
+    });
+
+    test("shows an off-pace milestone's target but no reachable pace", () => {
+        // Experience is flat, so the stars milestone is projected but never
+        // reached: the target is still shown, the pace is infinite.
+        const start = makePIT({
+            queriedAt: new Date(T0),
+            experience: 1_000_000,
+            overall: makeStats({
+                gamesPlayed: 500,
+                wins: 300,
+                finalKills: 750,
+                finalDeaths: 250,
+            }),
+        });
+        const end = makePIT({
+            queriedAt: new Date(T0 + HOUR_MS),
+            experience: 1_000_000, // unchanged -> no stars pace
+            overall: makeStats({
+                gamesPlayed: 520,
+                wins: 315,
+                finalKills: 810,
+                finalDeaths: 260,
+            }),
+        });
+        const session = makeSession(start, end);
+
+        const { prestige } = milestonesByKey(session);
+
+        expect(prestige?.target).not.toBeNull();
+        expect(prestige?.sessions).toBe(Number.POSITIVE_INFINITY);
+        expect(prestige?.playtimeMs).toBe(0);
+        expect(prestige?.blockedReason).toBe("Not on pace to reach this");
+        expect(prestige?.current).toBeCloseTo(
+            bedwarsLevelFromExp(session.end.experience),
+        );
+    });
+});
+
+const ZERO_AGG: SessionAggregate = {
+    games: 0,
+    wins: 0,
+    losses: 0,
+    fk: 0,
+    fd: 0,
+    bb: 0,
+    bl: 0,
+    k: 0,
+    d: 0,
+    xp: 0,
+    stars: 0,
+    fkdr: 0,
+    lifetimeFkdr: 0,
+    winRate: 0,
+    lifetimeWR: 0,
+    elapsedMs: 0,
+};
+
+const makeAgg = (overrides: Partial<SessionAggregate>): SessionAggregate => ({
+    ...ZERO_AGG,
+    ...overrides,
+});
+
+describe(sessionTagKeys, () => {
+    const HOUR_MS = 60 * 60 * 1000;
+    const cases: {
+        name: string;
+        agg: Partial<SessionAggregate>;
+        expected: string[];
+    }[] = [
+        {
+            name: "an unremarkable session earns nothing",
+            agg: { games: 1 },
+            expected: [],
+        },
+        {
+            name: "flawless: 2+ games, no losses, no final deaths",
+            agg: { games: 2, losses: 0, fd: 0 },
+            expected: ["flawless"],
+        },
+        {
+            name: "flawless beats perfect when both would apply",
+            agg: { games: 5, losses: 0, fd: 0 },
+            expected: ["flawless"],
+        },
+        {
+            name: "perfect: 3+ wins but took a final death",
+            agg: { games: 3, wins: 3, losses: 0, fd: 1 },
+            expected: ["perfect"],
+        },
+        {
+            name: "not perfect when a draw means not every game was won",
+            agg: { games: 3, wins: 2, losses: 0, fd: 1 },
+            expected: [],
+        },
+        {
+            name: "neither flawless nor perfect with only 2 games and a final death",
+            agg: { games: 2, losses: 0, fd: 1 },
+            expected: [],
+        },
+        {
+            name: "on_fire: FKDR well above lifetime with enough finals",
+            agg: { games: 1, losses: 1, fkdr: 3, lifetimeFkdr: 2, fk: 6 },
+            expected: ["on_fire"],
+        },
+        {
+            name: "on_fire needs at least 6 final kills",
+            agg: { games: 1, losses: 1, fkdr: 3, lifetimeFkdr: 2, fk: 5 },
+            expected: [],
+        },
+        {
+            name: "marathon: at least three hours played",
+            agg: { games: 1, losses: 1, elapsedMs: 3 * HOUR_MS },
+            expected: ["marathon"],
+        },
+        {
+            name: "tags stack",
+            agg: {
+                games: 4,
+                losses: 0,
+                fd: 0,
+                fkdr: 10,
+                lifetimeFkdr: 2,
+                fk: 8,
+                elapsedMs: 4 * HOUR_MS,
+            },
+            expected: ["flawless", "on_fire", "marathon"],
+        },
+    ];
+
+    test.each(cases)("$name", ({ agg, expected }) => {
+        expect(sessionTagKeys(makeAgg(agg))).toStrictEqual(expected);
+    });
+});
+
+describe(fkdrVsLifetime, () => {
+    const cases: {
+        name: string;
+        agg: Partial<SessionAggregate>;
+        expected: "beating" | "on_par" | "below";
+    }[] = [
+        {
+            name: "clearly above",
+            agg: { fkdr: 2, lifetimeFkdr: 1 },
+            expected: "beating",
+        },
+        {
+            name: "clearly below",
+            agg: { fkdr: 0.5, lifetimeFkdr: 1 },
+            expected: "below",
+        },
+        {
+            name: "within the band",
+            agg: { fkdr: 1.05, lifetimeFkdr: 1 },
+            expected: "on_par",
+        },
+        {
+            name: "exactly +10% is beating",
+            agg: { fkdr: 1.1, lifetimeFkdr: 1 },
+            expected: "beating",
+        },
+        {
+            name: "exactly -10% is below",
+            agg: { fkdr: 0.9, lifetimeFkdr: 1 },
+            expected: "below",
+        },
+        {
+            name: "no lifetime finals but positive session FKDR is beating",
+            agg: { fkdr: 3, lifetimeFkdr: 0 },
+            expected: "beating",
+        },
+        {
+            name: "no lifetime finals and no session finals is on par",
+            agg: { fkdr: 0, lifetimeFkdr: 0 },
+            expected: "on_par",
+        },
+    ];
+
+    test.each(cases)("$name", ({ agg, expected }) => {
+        expect(fkdrVsLifetime(makeAgg(agg))).toBe(expected);
+    });
+});
+
+describe(isPerfectGame, () => {
+    const cases: {
+        name: string;
+        game: Partial<GameResult>;
+        expected: boolean;
+    }[] = [
+        {
+            name: "fours: both thresholds met",
+            game: { gamemode: "fours", finalKills: 16, bedsBroken: 3 },
+            expected: true,
+        },
+        {
+            name: "fours: one bed short",
+            game: { gamemode: "fours", finalKills: 16, bedsBroken: 2 },
+            expected: false,
+        },
+        {
+            name: "fours: one final short",
+            game: { gamemode: "fours", finalKills: 15, bedsBroken: 3 },
+            expected: false,
+        },
+        {
+            name: "exceeding the thresholds still counts",
+            game: { gamemode: "fours", finalKills: 20, bedsBroken: 5 },
+            expected: true,
+        },
+        {
+            name: "solo thresholds",
+            game: { gamemode: "solo", finalKills: 7, bedsBroken: 7 },
+            expected: true,
+        },
+        {
+            name: "4v4 thresholds",
+            game: { gamemode: "4v4", finalKills: 4, bedsBroken: 1 },
+            expected: true,
+        },
+    ];
+
+    test.each(cases)("$name", ({ game, expected }) => {
+        expect(isPerfectGame(makeGame(game))).toBe(expected);
+    });
+});
+
+describe(gameAccolade, () => {
+    const cases: {
+        name: string;
+        game: Partial<GameResult>;
+        expected: "perfect" | "carried" | "clutch" | null;
+    }[] = [
+        { name: "a loss has no accolade", game: { outcome: "loss" }, expected: null },
+        { name: "a draw has no accolade", game: { outcome: "draw" }, expected: null },
+        {
+            name: "perfect game wins outright",
+            game: {
+                gamemode: "fours",
+                finalKills: 16,
+                bedsBroken: 3,
+                finalDeath: true,
+            },
+            expected: "perfect",
+        },
+        {
+            name: "carried: won after a final death",
+            game: { finalDeath: true, bedLost: true },
+            expected: "carried",
+        },
+        {
+            name: "clutch: won after losing the bed (no final death)",
+            game: { finalDeath: false, bedLost: true },
+            expected: "clutch",
+        },
+        {
+            name: "an unremarkable win has no accolade",
+            game: { finalDeath: false, bedLost: false },
+            expected: null,
+        },
+    ];
+
+    test.each(cases)("$name", ({ game, expected }) => {
+        expect(gameAccolade(makeGame(game))).toBe(expected);
+    });
+});

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -2,6 +2,7 @@ import { http, HttpResponse } from "msw";
 
 import { isNormalizedUUID } from "#helpers/uuid.ts";
 import type { APIPlayerDataPIT } from "#queries/playerdata.ts";
+import type { APISessionAtResponse } from "#queries/sessionAt.ts";
 import type { APISession } from "#queries/sessions.ts";
 import type { APIUsernameResponse } from "#queries/username.ts";
 import type { APIUUIDResponse } from "#queries/uuid.ts";
@@ -106,6 +107,81 @@ export const handlers = [
             makePlayerDataPIT(body.uuid, midDate.toISOString(), 2),
             makePlayerDataPIT(body.uuid, endDate.toISOString(), 3),
         ].slice(0, body.limit);
+
+        return HttpResponse.json(response);
+    }),
+    http.post(flashlightEndpoint("v1/session-at"), async ({ request }) => {
+        const body = (await request.json()) as {
+            uuid: string;
+            time: string;
+        };
+        validateUUID(body.uuid);
+
+        const timeDate = new Date(body.time);
+        const startDate = new Date(timeDate.getTime() - 60 * 60 * 1000);
+        const midDate = new Date(timeDate);
+        const mid2Date = new Date(timeDate.getTime() + 30 * 60 * 1000);
+        const endDate = new Date(timeDate.getTime() + 60 * 60 * 1000);
+
+        const startPIT = makePlayerDataPIT(body.uuid, startDate.toISOString(), 1);
+        const midPIT = makePlayerDataPIT(body.uuid, midDate.toISOString(), 2);
+        const mid2PIT = makePlayerDataPIT(body.uuid, mid2Date.toISOString(), 3);
+        const endPIT = makePlayerDataPIT(body.uuid, endDate.toISOString(), 4);
+
+        const response: APISessionAtResponse = {
+            session: makeSession(
+                body.uuid,
+                startDate.toISOString(),
+                endDate.toISOString(),
+            ),
+            games: [
+                {
+                    start: startPIT,
+                    end: midPIT,
+                    game: {
+                        gamemode: "doubles",
+                        outcome: "win",
+                        finalKills: 5,
+                        finalDeath: true,
+                        bedsBroken: 1,
+                        bedLost: false,
+                        kills: 12,
+                        deaths: 4,
+                        experience: 2400,
+                    },
+                },
+                {
+                    start: midPIT,
+                    end: mid2PIT,
+                    game: {
+                        gamemode: "fours",
+                        outcome: "loss",
+                        finalKills: 2,
+                        finalDeath: true,
+                        bedsBroken: 0,
+                        bedLost: true,
+                        kills: 6,
+                        deaths: 5,
+                        experience: 700,
+                    },
+                },
+                {
+                    start: mid2PIT,
+                    end: endPIT,
+                    game: {
+                        gamemode: "4v4",
+                        outcome: "win",
+                        finalKills: 3,
+                        finalDeath: false,
+                        bedsBroken: 1,
+                        bedLost: false,
+                        kills: 8,
+                        deaths: 2,
+                        experience: 1800,
+                    },
+                },
+            ],
+        };
 
         return HttpResponse.json(response);
     }),

--- a/src/queries/sessionAt.ts
+++ b/src/queries/sessionAt.ts
@@ -1,0 +1,205 @@
+import { captureException, captureMessage } from "@sentry/react";
+import { queryOptions } from "@tanstack/react-query";
+
+import { env } from "#env.ts";
+import { getOrSetUserId } from "#helpers/userId.ts";
+import { isNormalizedUUID } from "#helpers/uuid.ts";
+import { ALL_GAMEMODE_KEYS } from "#stats/keys.ts";
+import type { GamemodeKey } from "#stats/keys.ts";
+import { MS_PER_MINUTE } from "#time.ts";
+
+import { apiToPlayerDataPIT } from "./playerdata.ts";
+import type { APIPlayerDataPIT, PlayerDataPIT } from "./playerdata.ts";
+import type { APISession, Session } from "./sessions.ts";
+import { apiToSession } from "./sessions.ts";
+
+// The real gamemodes — every GamemodeKey except the "overall" aggregate.
+export type Gamemode = Exclude<GamemodeKey, "overall">;
+
+const isGamemode = (value: unknown): value is Gamemode =>
+    typeof value === "string" &&
+    value !== "overall" &&
+    (ALL_GAMEMODE_KEYS as readonly string[]).includes(value);
+
+// How a single game ended. Draws are rare in Bedwars but do happen, so this is
+// a three-state enum rather than a won/lost boolean. Mirrors the flashlight
+// `session-at` wire contract (`"outcome": "win" | "loss" | "draw"`).
+export const GAME_OUTCOMES = ["win", "loss", "draw"] as const;
+export type GameOutcome = (typeof GAME_OUTCOMES)[number];
+
+const isGameOutcome = (value: unknown): value is GameOutcome =>
+    typeof value === "string" && (GAME_OUTCOMES as readonly string[]).includes(value);
+
+interface APIGameResult {
+    readonly gamemode: string;
+    readonly outcome: string;
+    readonly finalKills: number;
+    readonly finalDeath: boolean;
+    readonly bedsBroken: number;
+    readonly bedLost: boolean;
+    readonly kills: number;
+    readonly deaths: number;
+    readonly experience: number;
+}
+
+interface APIGameSegment {
+    readonly start: APIPlayerDataPIT;
+    readonly end: APIPlayerDataPIT;
+    readonly game: APIGameResult | null;
+}
+
+export interface APISessionAtResponse {
+    readonly session: APISession | null;
+    readonly games: readonly APIGameSegment[];
+}
+
+export interface GameResult {
+    readonly gamemode: Gamemode;
+    readonly outcome: GameOutcome;
+    readonly finalKills: number;
+    // Booleans: at most one final death and one bed lost happen per game.
+    readonly finalDeath: boolean;
+    readonly bedsBroken: number;
+    readonly bedLost: boolean;
+    readonly kills: number;
+    readonly deaths: number;
+    readonly experience: number;
+}
+
+export interface GameSegment {
+    readonly start: PlayerDataPIT;
+    readonly end: PlayerDataPIT;
+    // null when the snapshot pair represents zero games (no game played) or
+    // more than one game (gamesPlayed jumped by 2+, or multiple modes
+    // advanced). Callers should render these specially — e.g. "(no games)"
+    // for no-game windows or "(N games played)" for ambiguous stretches.
+    readonly game: GameResult | null;
+}
+
+export interface SessionAt {
+    readonly session: Session | null;
+    readonly games: readonly GameSegment[];
+}
+
+const apiToGameResult = (api: APIGameResult): GameResult | null => {
+    if (!isGamemode(api.gamemode)) {
+        captureMessage("Unknown gamemode in session-at response", {
+            level: "error",
+            extra: { gamemode: api.gamemode },
+        });
+        return null;
+    }
+    if (!isGameOutcome(api.outcome)) {
+        captureMessage("Unknown outcome in session-at response", {
+            level: "error",
+            extra: { outcome: api.outcome },
+        });
+        return null;
+    }
+    return {
+        gamemode: api.gamemode,
+        outcome: api.outcome,
+        finalKills: api.finalKills,
+        finalDeath: api.finalDeath,
+        bedsBroken: api.bedsBroken,
+        bedLost: api.bedLost,
+        kills: api.kills,
+        deaths: api.deaths,
+        experience: api.experience,
+    };
+};
+
+interface SessionAtQueryOptions {
+    readonly uuid: string;
+    readonly time: Date;
+}
+
+// How often to refetch while a session is still ongoing. Games last a few
+// minutes, so a minute keeps the LIVE badge honest without hammering the API.
+const ONGOING_REFETCH_MS = MS_PER_MINUTE;
+
+export const getSessionAtQueryOptions = ({ uuid, time }: SessionAtQueryOptions) => {
+    const timeISOString = time.toISOString();
+
+    return queryOptions({
+        // An ended session is immutable, so cache it forever. An ongoing one
+        // keeps changing behind the LIVE badge, so let it go stale and refetch
+        // on an interval — otherwise the "live" numbers freeze at first load.
+        staleTime: (query) =>
+            query.state.data?.session?.ongoing === true ? ONGOING_REFETCH_MS : Infinity,
+        refetchInterval: (query) =>
+            query.state.data?.session?.ongoing === true ? ONGOING_REFETCH_MS : false,
+        queryKey: ["sessionAt", uuid, timeISOString],
+        queryFn: async (): Promise<SessionAt> => {
+            if (!isNormalizedUUID(uuid)) {
+                captureMessage("Failed to get session-at: uuid is not normalized", {
+                    level: "error",
+                    extra: { uuid, time: timeISOString },
+                });
+                throw new Error(`UUID not normalized: ${uuid}`);
+            }
+
+            const response = await fetch(
+                // NOTE: The flashlight API does **not** allow third-party access.
+                //       Do not send any requests to any endpoints without explicit permission.
+                //       Reach out on Discord for more information. https://discord.gg/k4FGUnEHYg
+                `${env.VITE_FLASHLIGHT_URL}/v1/session-at`,
+                {
+                    headers: {
+                        "Content-Type": "application/json",
+                        "X-User-Id": getOrSetUserId(),
+                    },
+                    method: "POST",
+                    body: JSON.stringify({ uuid, time: timeISOString }),
+                },
+            ).catch((error: unknown) => {
+                captureException(error, {
+                    extra: {
+                        uuid,
+                        time: timeISOString,
+                        message: "Failed to get session-at: failed to fetch",
+                    },
+                });
+                throw error;
+            });
+
+            if (!response.ok) {
+                const text = await response.text().catch(() => "");
+                captureMessage("Failed to get session-at: response error", {
+                    level: "error",
+                    tags: {
+                        status: response.status,
+                        statusText: response.statusText,
+                    },
+                    extra: { uuid, time: timeISOString, text },
+                });
+                throw new Error(
+                    `Failed to fetch session-at. ${response.status.toString()} - ${response.statusText}`,
+                );
+            }
+
+            const data = (await response.json().catch((error: unknown) => {
+                captureException(error, {
+                    extra: {
+                        uuid,
+                        time: timeISOString,
+                        message: "Failed to get session-at: failed to parse json",
+                    },
+                });
+                throw error;
+            })) as APISessionAtResponse;
+
+            return {
+                session:
+                    data.session === null ? null : apiToSession(data.session, false),
+                games: data.games.map(
+                    (seg): GameSegment => ({
+                        start: apiToPlayerDataPIT(seg.start),
+                        end: apiToPlayerDataPIT(seg.end),
+                        game: seg.game === null ? null : apiToGameResult(seg.game),
+                    }),
+                ),
+            };
+        },
+    });
+};

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as SessionIndexRouteImport } from './routes/session/index.tsx'
 import { Route as WrappedUuidRouteImport } from './routes/wrapped/$uuid.tsx'
 import { Route as SessionUuidRouteImport } from './routes/session/$uuid.tsx'
 import { Route as HistoryExploreRouteImport } from './routes/history.explore.tsx'
+import { Route as SessionUuidDetailRouteImport } from './routes/session/$uuid_.detail.tsx'
 
 const SettingsRoute = SettingsRouteImport.update({
   id: '/settings',
@@ -64,6 +65,11 @@ const HistoryExploreRoute = HistoryExploreRouteImport.update({
   path: '/history/explore',
   getParentRoute: () => rootRouteImport,
 } as any)
+const SessionUuidDetailRoute = SessionUuidDetailRouteImport.update({
+  id: '/session/$uuid_/detail',
+  path: '/session/$uuid/detail',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -75,6 +81,7 @@ export interface FileRoutesByFullPath {
   '/wrapped/$uuid': typeof WrappedUuidRoute
   '/session/': typeof SessionIndexRoute
   '/wrapped/': typeof WrappedIndexRoute
+  '/session/$uuid/detail': typeof SessionUuidDetailRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -86,6 +93,7 @@ export interface FileRoutesByTo {
   '/wrapped/$uuid': typeof WrappedUuidRoute
   '/session': typeof SessionIndexRoute
   '/wrapped': typeof WrappedIndexRoute
+  '/session/$uuid/detail': typeof SessionUuidDetailRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -98,6 +106,7 @@ export interface FileRoutesById {
   '/wrapped/$uuid': typeof WrappedUuidRoute
   '/session/': typeof SessionIndexRoute
   '/wrapped/': typeof WrappedIndexRoute
+  '/session/$uuid_/detail': typeof SessionUuidDetailRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -111,6 +120,7 @@ export interface FileRouteTypes {
     | '/wrapped/$uuid'
     | '/session/'
     | '/wrapped/'
+    | '/session/$uuid/detail'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -122,6 +132,7 @@ export interface FileRouteTypes {
     | '/wrapped/$uuid'
     | '/session'
     | '/wrapped'
+    | '/session/$uuid/detail'
   id:
     | '__root__'
     | '/'
@@ -133,6 +144,7 @@ export interface FileRouteTypes {
     | '/wrapped/$uuid'
     | '/session/'
     | '/wrapped/'
+    | '/session/$uuid_/detail'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -145,6 +157,7 @@ export interface RootRouteChildren {
   WrappedUuidRoute: typeof WrappedUuidRoute
   SessionIndexRoute: typeof SessionIndexRoute
   WrappedIndexRoute: typeof WrappedIndexRoute
+  SessionUuidDetailRoute: typeof SessionUuidDetailRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -212,6 +225,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof HistoryExploreRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/session/$uuid_/detail': {
+      id: '/session/$uuid_/detail'
+      path: '/session/$uuid/detail'
+      fullPath: '/session/$uuid/detail'
+      preLoaderRoute: typeof SessionUuidDetailRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -225,6 +245,7 @@ const rootRouteChildren: RootRouteChildren = {
   WrappedUuidRoute: WrappedUuidRoute,
   SessionIndexRoute: SessionIndexRoute,
   WrappedIndexRoute: WrappedIndexRoute,
+  SessionUuidDetailRoute: SessionUuidDetailRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/session/$uuid.tsx
+++ b/src/routes/session/$uuid.tsx
@@ -1,4 +1,4 @@
-import { Info, InfoOutlined, QueryStats, Warning } from "@mui/icons-material";
+import { Info, InfoOutlined, QueryStats, Search, Warning } from "@mui/icons-material";
 import {
     Box,
     Card,
@@ -370,6 +370,8 @@ const Sessions: React.FC<SessionsProps> = ({
                                             }}
                                         />
                                     )}
+                                    {/* Cell for the detail-page magnifying-glass icon */}
+                                    <TableCell padding="none" style={{ width: 1 }} />
                                     <TableCell>
                                         <Typography variant="subtitle2">
                                             Start
@@ -508,6 +510,30 @@ const Sessions: React.FC<SessionsProps> = ({
                                                             )}
                                                     </TableCell>
                                                 )}
+                                                <TableCell
+                                                    padding="none"
+                                                    style={{ width: 1 }}
+                                                    align="center"
+                                                >
+                                                    {!session.extrapolated && (
+                                                        <Tooltip title="Open session detail">
+                                                            <RouterLinkIconButton
+                                                                size="small"
+                                                                color="primary"
+                                                                sx={{ p: 0.25 }}
+                                                                from="/session/$uuid"
+                                                                to="/session/$uuid/detail"
+                                                                params={{ uuid }}
+                                                                search={{
+                                                                    date: session.start
+                                                                        .queriedAt,
+                                                                }}
+                                                            >
+                                                                <Search fontSize="small" />
+                                                            </RouterLinkIconButton>
+                                                        </Tooltip>
+                                                    )}
+                                                </TableCell>
                                                 <TableCell>
                                                     <Typography
                                                         variant="body1"

--- a/src/routes/session/$uuid_.detail.tsx
+++ b/src/routes/session/$uuid_.detail.tsx
@@ -1,0 +1,2077 @@
+import {
+    AutoAwesome,
+    Bed,
+    Block,
+    Bolt,
+    Cloud,
+    ContentCopy,
+    DirectionsRun,
+    EmojiEvents,
+    Group,
+    HeartBroken,
+    Help,
+    Info,
+    IosShare,
+    LocalFireDepartment,
+    MilitaryTech,
+    Schedule,
+    Shield,
+    Speed,
+    SportsEsports,
+    Star,
+    StopCircle,
+    TrendingDown,
+    TrendingFlat,
+    TrendingUp,
+    Verified,
+    WorkspacePremium,
+} from "@mui/icons-material";
+import type { SvgIconComponent } from "@mui/icons-material";
+import {
+    Alert,
+    Box,
+    Button,
+    Chip,
+    LinearProgress,
+    Skeleton,
+    Snackbar,
+    Stack,
+    Tooltip,
+    Typography,
+    useTheme,
+} from "@mui/material";
+import { alpha } from "@mui/material/styles";
+import type { Palette, Theme } from "@mui/material/styles";
+import { captureException } from "@sentry/react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, Navigate } from "@tanstack/react-router";
+import React from "react";
+import {
+    Area,
+    CartesianGrid,
+    ComposedChart,
+    Line,
+    Tooltip as ChartTooltip,
+    XAxis,
+    YAxis,
+} from "recharts";
+
+import { PlayerHead } from "#components/player.tsx";
+import { TrendIcon } from "#components/TrendIcon.tsx";
+import { formatDuration } from "#helpers/duration.ts";
+import type {
+    GameAccoladeKind,
+    Milestone,
+    ModeBreakdownKey,
+    ModeStats,
+    SegmentGameNumber,
+    SessionAggregate,
+    SessionTagKey,
+} from "#helpers/sessionDetail.ts";
+import {
+    aggregate,
+    bestGame,
+    computeMilestones,
+    fastestWin,
+    fkdrTrajectory,
+    fkdrVsLifetime,
+    GAMEMODES,
+    gameAccolade,
+    gameNumberLabel,
+    inferredGameCount,
+    modeBreakdown,
+    segmentDurationMs,
+    segmentExperience,
+    segmentGameNumbers,
+    sessionTagKeys,
+    statDelta,
+    trailingStreak,
+} from "#helpers/sessionDetail.ts";
+import { normalizeUUID } from "#helpers/uuid.ts";
+import type {
+    GameOutcome,
+    GameResult,
+    GameSegment,
+    SessionAt,
+} from "#queries/sessionAt.ts";
+import { getSessionAtQueryOptions } from "#queries/sessionAt.ts";
+import { useUUIDToUsername } from "#queries/username.ts";
+import { detailSearchSchema } from "#schemas/detailSearch.ts";
+import {
+    formatStatValue,
+    getTrendDirection,
+    getTrendSentiment,
+} from "#stats/format.ts";
+import type { TrendSentiment } from "#stats/format.ts";
+import type { StatKey } from "#stats/keys.ts";
+import { getGamemodeLabel, getShortStatLabel } from "#stats/labels.ts";
+import { bedwarsLevelFromExp } from "#stats/stars.ts";
+import { rainbowGradient } from "#theme/tokens.ts";
+import { MS_PER_HOUR, MS_PER_MINUTE } from "#time.ts";
+
+export const Route = createFileRoute("/session/$uuid_/detail")({
+    validateSearch: detailSearchSchema,
+    // oxlint-disable-next-line eslint/no-use-before-define
+    component: RouteComponent,
+});
+
+const MILESTONE_ICONS: Record<Milestone["key"], SvgIconComponent> = {
+    prestige: AutoAwesome,
+    wins: EmojiEvents,
+    fkdr: TrendingUp,
+};
+
+// The stat each milestone tracks, so its current→target trend can be coloured
+// with the app's shared sentiment logic (all three are "higher is better").
+const MILESTONE_STAT: Record<Milestone["key"], StatKey> = {
+    prestige: "stars",
+    wins: "wins",
+    fkdr: "fkdr",
+};
+
+interface SessionTag {
+    readonly key: SessionTagKey;
+    readonly label: string;
+    readonly icon: SvgIconComponent;
+    readonly tooltip: string;
+}
+
+// Dress each earned badge (see sessionTagKeys) with an icon, label and tooltip.
+// The eligibility logic lives in the helper; this only handles presentation.
+const computeTags = (agg: SessionAggregate): SessionTag[] =>
+    sessionTagKeys(agg).map((key): SessionTag => {
+        switch (key) {
+            case "flawless": {
+                return {
+                    key,
+                    label: "Flawless",
+                    icon: Verified,
+                    tooltip: "No losses and no final deaths this session",
+                };
+            }
+            case "perfect": {
+                return {
+                    key,
+                    label: "Perfect run",
+                    icon: WorkspacePremium,
+                    tooltip: "Won every game this session",
+                };
+            }
+            case "on_fire": {
+                return {
+                    key,
+                    label: "On fire",
+                    icon: LocalFireDepartment,
+                    tooltip: `${formatStatValue("fkdr", agg.fkdr)} session FKDR vs ${formatStatValue("fkdr", agg.lifetimeFkdr)} lifetime`,
+                };
+            }
+            case "marathon": {
+                return {
+                    key,
+                    label: "Marathon",
+                    icon: DirectionsRun,
+                    tooltip: `${(agg.elapsedMs / MS_PER_HOUR).toFixed(1)} hours played`,
+                };
+            }
+        }
+    });
+
+// Accent colours for the auto-derived tags. Pulled from the theme rather than
+// hand-picked hex: semantic tokens where a tag has an obvious mood (flawless =
+// warning gold, perfect = win green) and rainbow/secondary accents otherwise.
+const tagColor = (
+    // oxlint-disable-next-line typescript/prefer-readonly-parameter-types
+    theme: Theme,
+    key: SessionTagKey,
+): string => {
+    switch (key) {
+        case "flawless": {
+            return theme.palette.warning.main;
+        }
+        case "perfect": {
+            return theme.palette.success.main;
+        }
+        case "on_fire": {
+            return theme.palette.rainbow[0];
+        }
+        case "marathon": {
+            return theme.palette.secondary.main;
+        }
+    }
+};
+
+const milestoneColor = (
+    // oxlint-disable-next-line typescript/prefer-readonly-parameter-types
+    theme: Theme,
+    key: Milestone["key"],
+): string => {
+    switch (key) {
+        case "prestige": {
+            return theme.palette.secondary.main;
+        }
+        case "wins": {
+            return theme.palette.success.main;
+        }
+        case "fkdr": {
+            return theme.palette.info.main;
+        }
+    }
+};
+
+const OUTCOME_LABEL: Record<GameOutcome, string> = {
+    win: "W",
+    loss: "L",
+    draw: "D",
+};
+
+const OUTCOME_FULL_LABEL: Record<GameOutcome, string> = {
+    win: "WIN",
+    loss: "LOSS",
+    draw: "DRAW",
+};
+
+// Why a window can have unattributable games — mirrors the session-list copy.
+const TRACKING_NOTE =
+    'The Prism Overlay only records games when the player is using it with "Online Game Stats" enabled in their Hypixel settings.';
+
+// win → success green, loss → error red, draw → neutral (rare, neither good nor bad).
+const outcomeColor = (
+    // oxlint-disable-next-line typescript/prefer-readonly-parameter-types
+    theme: Theme,
+    outcome: GameOutcome,
+): string => {
+    switch (outcome) {
+        case "win": {
+            return theme.palette.success.main;
+        }
+        case "loss": {
+            return theme.palette.error.main;
+        }
+        case "draw": {
+            return theme.palette.text.secondary;
+        }
+    }
+};
+
+const Panel: React.FC<{ children: React.ReactNode; sx?: object }> = ({
+    children,
+    sx,
+}) => (
+    <Box
+        sx={{
+            bgcolor: "background.paper",
+            border: 1,
+            borderColor: "divider",
+            borderRadius: 1.5,
+            p: 2.5,
+            ...sx,
+        }}
+    >
+        {children}
+    </Box>
+);
+
+const NoSession: React.FC<{ username: string }> = ({ username }) => (
+    <Box
+        sx={{
+            borderRadius: 1.5,
+            border: 1,
+            borderColor: "divider",
+            p: 4,
+            textAlign: "center",
+        }}
+    >
+        <Info color="info" fontSize="large" />
+        <Typography variant="h6" sx={{ mt: 1 }}>
+            No session yet
+        </Typography>
+        <Typography variant="body2" color="textSecondary" sx={{ mt: 1 }}>
+            {`${username} has no recorded session overlapping this date. Come back after they've played a game with the Prism Overlay running.`}
+        </Typography>
+    </Box>
+);
+
+const EndedBadge: React.FC = () => (
+    <Chip
+        icon={<StopCircle sx={{ fontSize: 12 }} />}
+        label="ENDED"
+        size="small"
+        sx={{
+            fontSize: 11,
+            fontWeight: 600,
+            letterSpacing: 1,
+            color: "text.secondary",
+            bgcolor: "action.hover",
+        }}
+    />
+);
+
+const LiveBadge: React.FC = () => (
+    <Chip
+        label="LIVE"
+        size="small"
+        sx={{
+            fontSize: 11,
+            fontWeight: 600,
+            letterSpacing: 1,
+            color: "success.main",
+            bgcolor: (theme) => alpha(theme.palette.success.main, 0.12),
+            "& .MuiChip-label": {
+                pl: 1.5,
+                position: "relative",
+                "&::before": {
+                    content: '""',
+                    position: "absolute",
+                    left: 4,
+                    top: "50%",
+                    transform: "translateY(-50%)",
+                    width: 6,
+                    height: 6,
+                    borderRadius: "50%",
+                    bgcolor: "success.main",
+                    animation: "rbw-pulse 1.6s ease-in-out infinite",
+                },
+            },
+            "@keyframes rbw-pulse": {
+                "0%, 100%": { opacity: 1, transform: "translateY(-50%) scale(1)" },
+                "50%": { opacity: 0.4, transform: "translateY(-50%) scale(1.3)" },
+            },
+        }}
+    />
+);
+
+interface PlayerBannerProps {
+    uuid: string;
+    username: string;
+    session: NonNullable<SessionAt["session"]>;
+    agg: SessionAggregate;
+    onShare: () => void;
+}
+
+const PlayerBanner: React.FC<PlayerBannerProps> = ({
+    uuid,
+    username,
+    session,
+    agg,
+    onShare,
+}) => {
+    const stars = Math.floor(bedwarsLevelFromExp(session.end.experience));
+    const startedAt = session.start.queriedAt;
+    const endedAt = session.end.queriedAt;
+    const startedDate = startedAt.toLocaleDateString(undefined, {
+        dateStyle: "medium",
+    });
+    const startedTime = startedAt.toLocaleTimeString(undefined, {
+        timeStyle: "short",
+    });
+    const endedTime = endedAt.toLocaleTimeString(undefined, {
+        timeStyle: "short",
+    });
+    return (
+        <Box
+            sx={{
+                position: "relative",
+                bgcolor: "background.paper",
+                border: 1,
+                borderColor: "divider",
+                borderRadius: 1.5,
+                p: 3,
+                overflow: "hidden",
+            }}
+        >
+            <Box
+                sx={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    height: 3,
+                    background: rainbowGradient(),
+                }}
+            />
+            <Stack
+                direction={{ xs: "column", sm: "row" }}
+                alignItems={{ xs: "stretch", sm: "center" }}
+                gap={2}
+            >
+                <PlayerHead uuid={uuid} username={username} variant="face" width={64} />
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Stack
+                        direction="row"
+                        alignItems="center"
+                        gap={1.5}
+                        flexWrap="wrap"
+                    >
+                        <Chip
+                            icon={<Star sx={{ color: "secondary.main" }} />}
+                            label={stars}
+                            size="small"
+                            sx={{
+                                color: "secondary.main",
+                                bgcolor: (theme) =>
+                                    alpha(theme.palette.secondary.main, 0.12),
+                                fontFamily: "monospace",
+                            }}
+                        />
+                        <Typography variant="h5">{username}</Typography>
+                        {session.ongoing ? <LiveBadge /> : <EndedBadge />}
+                    </Stack>
+                    <Stack
+                        direction="row"
+                        gap={3}
+                        flexWrap="wrap"
+                        sx={{ mt: 1 }}
+                        color="text.secondary"
+                    >
+                        <Stack direction="row" alignItems="center" gap={0.5}>
+                            <Schedule fontSize="small" />
+                            <Typography variant="body2">
+                                {`${startedDate} · ${startedTime}–${endedTime} · ${formatDuration(agg.elapsedMs)}`}
+                            </Typography>
+                        </Stack>
+                        <Stack direction="row" alignItems="center" gap={0.5}>
+                            <SportsEsports fontSize="small" />
+                            <Typography variant="body2">
+                                {`${agg.games.toString()} games`}
+                            </Typography>
+                        </Stack>
+                    </Stack>
+                </Box>
+                <Button
+                    variant="outlined"
+                    startIcon={<IosShare />}
+                    onClick={onShare}
+                    sx={{ alignSelf: { xs: "flex-start", sm: "center" } }}
+                >
+                    Share
+                </Button>
+            </Stack>
+        </Box>
+    );
+};
+
+const TagsRow: React.FC<{ tags: readonly SessionTag[] }> = ({ tags }) => {
+    const theme = useTheme();
+    return (
+        <Stack direction="row" gap={1} flexWrap="wrap">
+            {tags.map((tag) => {
+                const Icon = tag.icon;
+                const color = tagColor(theme, tag.key);
+                return (
+                    <Tooltip key={tag.key} title={tag.tooltip}>
+                        <Chip
+                            icon={<Icon sx={{ color: `${color} !important` }} />}
+                            label={tag.label}
+                            size="small"
+                            sx={{
+                                color,
+                                bgcolor: alpha(color, 0.08),
+                                border: 1,
+                                borderColor: alpha(color, 0.33),
+                                fontWeight: 600,
+                                letterSpacing: 0.3,
+                            }}
+                        />
+                    </Tooltip>
+                );
+            })}
+        </Stack>
+    );
+};
+
+// Dotted MUI palette colour paths (e.g. "success.main"), validated against the
+// theme so a typo like "sucess.main" fails to compile.
+type ThemeColor = {
+    [K in keyof Palette]: Palette[K] extends (...args: readonly never[]) => unknown
+        ? never
+        : Palette[K] extends object
+          ? `${K & string}.${keyof Palette[K] & string}`
+          : never;
+}[keyof Palette];
+
+// Delta/trend sentiment → theme colour (flat/neutral = muted). Shared by the
+// delta tags and the milestones card; the arrow icon comes from the shared
+// TREND_ICON map.
+const SENTIMENT_COLOR: Record<TrendSentiment, ThemeColor> = {
+    good: "success.main",
+    bad: "error.main",
+    neutral: "text.disabled",
+};
+
+const DeltaTag: React.FC<{
+    value: number;
+    suffix?: string;
+    stat: StatKey;
+}> = ({ value, suffix = "", stat }) => {
+    const direction = getTrendDirection(0, value);
+    const sentiment = getTrendSentiment(stat, direction);
+    const sign = direction === "up" ? "+" : "";
+    return (
+        <Stack
+            direction="row"
+            alignItems="center"
+            gap={0.5}
+            component="span"
+            sx={{ color: SENTIMENT_COLOR[sentiment] }}
+        >
+            <TrendIcon direction={direction} sx={{ fontSize: 14 }} />
+            <span>{`${sign}${value.toFixed(2)}${suffix} vs lifetime`}</span>
+        </Stack>
+    );
+};
+
+interface KpiCardProps {
+    label: string;
+    value: string;
+    sub: React.ReactNode;
+    accentColor?: string;
+}
+
+const KpiCard: React.FC<KpiCardProps> = ({ label, value, sub, accentColor }) => (
+    <Panel sx={{ p: 2 }}>
+        <Typography
+            variant="caption"
+            sx={{
+                color: "text.secondary",
+                textTransform: "uppercase",
+                letterSpacing: 0.8,
+            }}
+        >
+            {label}
+        </Typography>
+        <Typography
+            sx={{
+                fontSize: 30,
+                fontWeight: 400,
+                lineHeight: 1,
+                mt: 1,
+                mb: 0.75,
+                color: accentColor ?? "text.primary",
+            }}
+        >
+            {value}
+        </Typography>
+        <Typography variant="body2" color="textSecondary" component="div">
+            {sub}
+        </Typography>
+    </Panel>
+);
+
+const KPIRow: React.FC<{ agg: SessionAggregate }> = ({ agg }) => {
+    const fkdrDelta = agg.fkdr - agg.lifetimeFkdr;
+    const wrDelta = (agg.winRate - agg.lifetimeWR) * 100;
+    return (
+        <Box
+            sx={{
+                display: "grid",
+                gridTemplateColumns: { xs: "repeat(2, 1fr)", sm: "repeat(4, 1fr)" },
+                gap: 1.5,
+            }}
+        >
+            <KpiCard
+                label="Games"
+                value={agg.games.toString()}
+                sub={`${agg.wins.toString()}W · ${agg.losses.toString()}L`}
+            />
+            <KpiCard
+                label="Win rate"
+                value={formatStatValue("winrate", agg.winRate)}
+                sub={<DeltaTag value={wrDelta} suffix="%" stat="winrate" />}
+                accentColor="success.main"
+            />
+            <KpiCard
+                label="Session FKDR"
+                value={formatStatValue("fkdr", agg.fkdr)}
+                sub={<DeltaTag value={fkdrDelta} stat="fkdr" />}
+                accentColor="primary.main"
+            />
+            <KpiCard
+                label="Stars gained"
+                value={`+${formatStatValue("stars", agg.stars)}`}
+                sub={`${(agg.xp / 1000).toFixed(1)}k XP`}
+                accentColor="secondary.main"
+            />
+        </Box>
+    );
+};
+
+interface GameAccolade {
+    readonly icon: SvgIconComponent;
+    readonly color: string;
+    readonly label: string;
+    readonly tooltip: string;
+}
+
+// Icon/colour/label for a won-game accolade (the decision itself lives in the
+// gameAccolade helper). Shown icon-only on the tile and repeated as a labelled
+// chip in the expanded detail.
+const accoladePresentation = (
+    // oxlint-disable-next-line typescript/prefer-readonly-parameter-types
+    theme: Theme,
+    kind: GameAccoladeKind,
+): GameAccolade => {
+    switch (kind) {
+        case "perfect": {
+            return {
+                icon: MilitaryTech,
+                color: theme.palette.secondary.main,
+                label: "Perfect game",
+                tooltip: "Got every final kill and every enemy bed in the game.",
+            };
+        }
+        case "carried": {
+            return {
+                icon: Group,
+                color: theme.palette.info.main,
+                label: "Carried",
+                tooltip: "Won after taking a final death.",
+            };
+        }
+        case "clutch": {
+            return {
+                icon: Shield,
+                color: theme.palette.warning.main,
+                label: "Clutch",
+                tooltip: "Won after losing their bed.",
+            };
+        }
+    }
+};
+
+// Resolve a game's accolade to its presentation, or null when it has none.
+const gameAccoladeView = (
+    // oxlint-disable-next-line typescript/prefer-readonly-parameter-types
+    theme: Theme,
+    game: GameResult,
+): GameAccolade | null => {
+    const kind = gameAccolade(game);
+    return kind === null ? null : accoladePresentation(theme, kind);
+};
+
+// Rounded outline pill flagging what happened in the game (final death vs
+// survived, bed lost vs kept, or the won-game accolade). An optional tooltip
+// wraps the pill — the Stack forwards refs so MUI Tooltip anchors to it.
+const StatusPill: React.FC<{
+    icon: SvgIconComponent;
+    label: string;
+    color: string;
+    tooltip?: string;
+}> = ({ icon: Icon, label, color, tooltip }) => {
+    const pill = (
+        <Stack
+            direction="row"
+            alignItems="center"
+            gap={0.5}
+            sx={{
+                px: 1,
+                py: 0.25,
+                borderRadius: 5,
+                border: 1,
+                borderColor: alpha(color, 0.4),
+                bgcolor: alpha(color, 0.08),
+                color,
+            }}
+        >
+            <Icon sx={{ fontSize: 14 }} />
+            <Typography variant="caption" sx={{ fontWeight: 600 }}>
+                {label}
+            </Typography>
+        </Stack>
+    );
+    return tooltip === undefined ? pill : <Tooltip title={tooltip}>{pill}</Tooltip>;
+};
+
+const GameDetail: React.FC<{ segment: GameSegment; numbering: SegmentGameNumber }> = ({
+    segment,
+    numbering,
+}) => {
+    const theme = useTheme();
+    const xp = segmentExperience(segment);
+    const durationLabel = formatDuration(segmentDurationMs(segment));
+    // Same running-game-count label the strip tile shows (e.g. "G3", "G5-7").
+    const numberLabel = gameNumberLabel(numbering);
+
+    // Header context line + optional outcome badge + status pills + stat grid,
+    // derived per segment kind (real game / no-game window / multi-game gap).
+    let title: string;
+    let context: string;
+    let badge: { label: string; color: string } | null = null;
+    let pills: React.ReactNode = null;
+    let items: [string, string][];
+
+    if (segment.game === null) {
+        const count = inferredGameCount(segment);
+        if (count === 0) {
+            title = "Segment";
+            context = "No game";
+            items = [
+                ["GAMES", "0"],
+                ["XP", `+${xp.toLocaleString()}`],
+                ["SPAN", durationLabel],
+            ];
+        } else {
+            const delta = statDelta(segment.start.overall, segment.end.overall);
+            title = numberLabel ?? "Games";
+            context = `${count.toString()} game${count === 1 ? "" : "s"}`;
+            items = [
+                ["FINAL KILLS", delta.fk.toString()],
+                ["BEDS BROKEN", delta.bb.toString()],
+                ["KILLS / DEATHS", `${delta.k.toString()} / ${delta.d.toString()}`],
+                ["XP", `+${xp.toLocaleString()}`],
+            ];
+        }
+    } else {
+        const { game } = segment;
+        title = numberLabel ?? "Game";
+        context = getGamemodeLabel(game.gamemode, true);
+        badge = {
+            label: OUTCOME_FULL_LABEL[game.outcome],
+            color: outcomeColor(theme, game.outcome),
+        };
+        const accolade = gameAccoladeView(theme, game);
+        pills = (
+            <>
+                {accolade !== null && (
+                    <StatusPill
+                        icon={accolade.icon}
+                        label={accolade.label}
+                        color={accolade.color}
+                        tooltip={accolade.tooltip}
+                    />
+                )}
+                {game.finalDeath ? (
+                    <StatusPill
+                        icon={HeartBroken}
+                        label="Final death"
+                        color={theme.palette.error.main}
+                        tooltip="Player took a final death this game."
+                    />
+                ) : (
+                    <StatusPill
+                        icon={Shield}
+                        label="Survived"
+                        color={theme.palette.success.main}
+                        tooltip="Player did not take a final death this game."
+                    />
+                )}
+                {game.bedLost ? (
+                    <StatusPill
+                        icon={Bed}
+                        label="Bed lost"
+                        color={theme.palette.error.main}
+                        tooltip="Player's bed was broken this game."
+                    />
+                ) : (
+                    <StatusPill
+                        icon={Bed}
+                        label="Bed kept"
+                        color={theme.palette.success.main}
+                        tooltip="Player's bed was not broken this game."
+                    />
+                )}
+            </>
+        );
+        items = [
+            ["FINAL KILLS", game.finalKills.toString()],
+            ["BEDS BROKEN", game.bedsBroken.toString()],
+            ["KILLS / DEATHS", `${game.kills.toString()} / ${game.deaths.toString()}`],
+            ["XP", `+${game.experience.toLocaleString()}`],
+        ];
+    }
+
+    return (
+        <Box sx={{ mt: 1.75, pt: 1.75, borderTop: 1, borderColor: "divider" }}>
+            <Stack
+                direction="row"
+                justifyContent="space-between"
+                alignItems="center"
+                flexWrap="wrap"
+                gap={1}
+                sx={{ mb: 1.75, maxWidth: 720, mx: "auto" }}
+            >
+                <Stack direction="row" alignItems="center" gap={1} flexWrap="wrap">
+                    <Typography sx={{ fontWeight: 600 }}>{title}</Typography>
+                    <Typography variant="body2" color="textSecondary">
+                        {`· ${context} · ${durationLabel}`}
+                    </Typography>
+                    {badge !== null && (
+                        <Typography
+                            component="span"
+                            sx={{
+                                px: 0.875,
+                                py: 0.25,
+                                borderRadius: 0.75,
+                                bgcolor: alpha(badge.color, 0.15),
+                                color: badge.color,
+                                fontSize: 11,
+                                fontWeight: 700,
+                                letterSpacing: 0.5,
+                            }}
+                        >
+                            {badge.label}
+                        </Typography>
+                    )}
+                </Stack>
+                {pills !== null && (
+                    <Stack direction="row" gap={1} flexWrap="wrap">
+                        {pills}
+                    </Stack>
+                )}
+            </Stack>
+            <Box
+                sx={{
+                    display: "grid",
+                    gridTemplateColumns: "repeat(4, 1fr)",
+                    gap: 1,
+                    maxWidth: 720,
+                    mx: "auto",
+                }}
+            >
+                {items.map(([label, value]) => (
+                    <Box key={label}>
+                        <Typography
+                            variant="caption"
+                            color="textSecondary"
+                            sx={{
+                                textTransform: "uppercase",
+                                letterSpacing: 0.6,
+                                fontSize: 10,
+                            }}
+                        >
+                            {label}
+                        </Typography>
+                        <Typography
+                            sx={{ fontFamily: "monospace", fontSize: 16, mt: 0.5 }}
+                        >
+                            {value}
+                        </Typography>
+                    </Box>
+                ))}
+            </Box>
+        </Box>
+    );
+};
+
+// Icon-only badge shown left of the W/L chip on a game tile — the same
+// accolade that the expanded detail repeats as a labelled chip.
+const ClutchOrCarriedBadge: React.FC<{ game: GameResult }> = ({ game }) => {
+    const theme = useTheme();
+    const accolade = gameAccoladeView(theme, game);
+    if (accolade === null) return null;
+    const Icon = accolade.icon;
+    return (
+        <Tooltip title={`${accolade.label} — ${accolade.tooltip}`}>
+            <Box
+                aria-label={accolade.label}
+                sx={{
+                    width: 18,
+                    height: 18,
+                    borderRadius: 0.75,
+                    bgcolor: alpha(accolade.color, 0.12),
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                }}
+            >
+                <Icon sx={{ fontSize: 12, color: accolade.color }} />
+            </Box>
+        </Tooltip>
+    );
+};
+
+const GameTile: React.FC<{
+    segment: GameSegment;
+    numbering: SegmentGameNumber;
+    active: boolean;
+    onClick: () => void;
+}> = ({ segment, numbering, active, onClick }) => {
+    const theme = useTheme();
+    const { game } = segment;
+    const durationMs = segmentDurationMs(segment);
+    const mins = Math.max(1, Math.round(durationMs / MS_PER_MINUTE));
+    // Running-game-count label (e.g. "G3", "G5-7"); null for a no-game window.
+    const numberLabel = gameNumberLabel(numbering);
+
+    if (game === null) {
+        const count = inferredGameCount(segment);
+        const noGame = count === 0;
+        const color = noGame ? theme.palette.textMuted : theme.palette.text.secondary;
+        const gapTooltip =
+            count === 1
+                ? `This game couldn't be attributed individually. ${TRACKING_NOTE}`
+                : `These ${count.toString()} games couldn't be attributed individually. ${TRACKING_NOTE}`;
+        const helpTooltip = noGame
+            ? `No game was attributed to this window. ${TRACKING_NOTE}`
+            : gapTooltip;
+        const gamesLabel = count === 1 ? "game" : "games";
+        return (
+            <Button
+                onClick={onClick}
+                aria-expanded={active}
+                sx={{
+                    px: 1.5,
+                    py: 1.25,
+                    borderRadius: 1.25,
+                    bgcolor: active ? alpha(color, 0.13) : "action.hover",
+                    border: 1,
+                    // Use a muted version of the tile colour (not the faint
+                    // `divider`) so the dashed border reads as dashed at rest —
+                    // otherwise the dashes only become visible once selected.
+                    borderColor: active ? color : alpha(color, 0.5),
+                    borderStyle: "dashed",
+                    color: "text.primary",
+                    textTransform: "none",
+                    textAlign: "left",
+                    flexDirection: "column",
+                    alignItems: "stretch",
+                    position: "relative",
+                    overflow: "hidden",
+                    minWidth: 0,
+                    "&:hover": { bgcolor: alpha(color, 0.07) },
+                }}
+            >
+                <Stack
+                    direction="row"
+                    alignItems="center"
+                    justifyContent="space-between"
+                    sx={{ mb: 0.5 }}
+                >
+                    <Typography variant="caption" sx={{ fontFamily: "monospace" }}>
+                        {numberLabel ?? ""}
+                    </Typography>
+                    <Tooltip title={helpTooltip}>
+                        <Help sx={{ fontSize: 14, color }} />
+                    </Tooltip>
+                </Stack>
+                <Typography sx={{ fontSize: 18, lineHeight: 1, fontWeight: 500 }}>
+                    {noGame ? "—" : count.toString()}
+                </Typography>
+                <Typography variant="caption" color="textSecondary">
+                    {noGame ? "no game" : gamesLabel}
+                </Typography>
+                <Stack direction="row" gap={0.75} sx={{ mt: 1, fontSize: 10 }}>
+                    <Typography variant="caption" color="textSecondary">
+                        ?
+                    </Typography>
+                    <Typography variant="caption" sx={{ ml: "auto" }}>
+                        {`${mins.toString()}m`}
+                    </Typography>
+                </Stack>
+            </Button>
+        );
+    }
+
+    const color = outcomeColor(theme, game.outcome);
+    return (
+        <Button
+            onClick={onClick}
+            aria-expanded={active}
+            sx={{
+                px: 1.5,
+                py: 1.25,
+                borderRadius: 1.25,
+                bgcolor: active ? alpha(color, 0.13) : "action.hover",
+                border: 1,
+                borderColor: active ? color : "divider",
+                color: "text.primary",
+                textTransform: "none",
+                textAlign: "left",
+                flexDirection: "column",
+                alignItems: "stretch",
+                position: "relative",
+                overflow: "hidden",
+                minWidth: 0,
+                "&:hover": { bgcolor: alpha(color, 0.07) },
+            }}
+        >
+            <Box
+                sx={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    height: 3,
+                    bgcolor: color,
+                }}
+            />
+            <Stack
+                direction="row"
+                alignItems="center"
+                justifyContent="space-between"
+                sx={{ mb: 0.5 }}
+            >
+                <Typography variant="caption" sx={{ fontFamily: "monospace" }}>
+                    {numberLabel ?? ""}
+                </Typography>
+                <Stack direction="row" alignItems="center" gap={0.5}>
+                    <ClutchOrCarriedBadge game={game} />
+                    <Chip
+                        size="small"
+                        label={OUTCOME_LABEL[game.outcome]}
+                        sx={{
+                            height: 18,
+                            fontSize: 10,
+                            fontWeight: 600,
+                            color,
+                            bgcolor: alpha(color, 0.12),
+                        }}
+                    />
+                </Stack>
+            </Stack>
+            <Typography sx={{ fontSize: 18, lineHeight: 1, fontWeight: 500 }}>
+                {game.finalKills.toString()}
+            </Typography>
+            <Typography variant="caption" color="textSecondary">
+                {game.finalKills === 1 ? "Final" : "Finals"}
+            </Typography>
+            <Stack direction="row" gap={0.75} sx={{ mt: 1, fontSize: 10 }}>
+                <Box sx={{ color: theme.palette.gamemode[game.gamemode] }}>●</Box>
+                <Typography variant="caption">
+                    {getGamemodeLabel(game.gamemode, true)}
+                </Typography>
+                <Typography variant="caption" sx={{ ml: "auto" }}>
+                    {`${mins.toString()}m`}
+                </Typography>
+            </Stack>
+        </Button>
+    );
+};
+
+const StreakIndicator: React.FC<{ segments: readonly GameSegment[] }> = ({
+    segments,
+}) => {
+    const theme = useTheme();
+    const streak = trailingStreak(segments);
+    // Draws don't form a meaningful streak to surface, so only win/loss runs show.
+    if (streak === null || streak.outcome === "draw") return null;
+    const won = streak.outcome === "win";
+    const color = won ? theme.palette.success.main : theme.palette.error.main;
+    const Icon = won ? LocalFireDepartment : Cloud;
+    const label = `${streak.length.toString()} ${won ? "winstreak" : "loss streak"}`;
+    return (
+        <Stack
+            direction="row"
+            alignItems="center"
+            gap={0.75}
+            sx={{
+                px: 1.25,
+                py: 0.75,
+                borderRadius: 0.75,
+                bgcolor: alpha(color, 0.08),
+                color,
+                flexShrink: 0,
+            }}
+        >
+            <Icon fontSize="small" sx={{ color }} />
+            <Typography
+                variant="body2"
+                sx={{ color, fontWeight: 600, whiteSpace: "nowrap" }}
+            >
+                {label}
+            </Typography>
+        </Stack>
+    );
+};
+
+const MomentumStrip: React.FC<{ segments: readonly GameSegment[] }> = ({
+    segments,
+}) => {
+    const [focused, setFocused] = React.useState<number | null>(null);
+    // This component keeps its place in the tree when the user navigates to
+    // another session, so `focused` would otherwise carry over and point at a
+    // different game in the new set. Reset it whenever the segments change.
+    const identity = segments.map((seg) => seg.end.queriedAt.toISOString()).join(",");
+    const [prevIdentity, setPrevIdentity] = React.useState(identity);
+    if (identity !== prevIdentity) {
+        setPrevIdentity(identity);
+        setFocused(null);
+    }
+    const focusedSegment = focused === null ? undefined : segments[focused];
+    // Number every segment by running game count so the tiles, the expanded
+    // detail and the trajectory chart all agree on which game is which.
+    const numbers = segmentGameNumbers(segments);
+    return (
+        <Panel>
+            <Box sx={{ mb: 1.5 }}>
+                <Stack
+                    direction="row"
+                    justifyContent="space-between"
+                    alignItems="center"
+                    gap={2}
+                    sx={{ mb: 0.5 }}
+                >
+                    <Typography variant="subtitle1">Game-by-game</Typography>
+                    <StreakIndicator segments={segments} />
+                </Stack>
+                <Typography variant="caption" color="textSecondary">
+                    Click a tile to inspect. Dashed tiles are gaps where individual
+                    games can&apos;t be attributed — either no game was played, or
+                    several couldn&apos;t be split apart.
+                </Typography>
+            </Box>
+            <Box
+                sx={{
+                    display: "grid",
+                    // Tiles share the row when there's room (1fr each), but
+                    // never shrink below 120px — past that the container
+                    // scrolls horizontally so long sessions stay legible
+                    // instead of squishing every tile.
+                    // Guard against `repeat(0, …)` — invalid CSS — for a
+                    // segment-less session; callers only render this with
+                    // games, but keep the grid template valid regardless.
+                    gridTemplateColumns: `repeat(${Math.max(1, segments.length).toString()}, minmax(120px, 1fr))`,
+                    gap: 1,
+                    overflowX: "auto",
+                    pb: 1,
+                }}
+            >
+                {segments.map((seg, i) => (
+                    <GameTile
+                        key={seg.end.queriedAt.toISOString()}
+                        segment={seg}
+                        numbering={numbers[i]}
+                        active={focused === i}
+                        onClick={() => {
+                            setFocused((prev) => (prev === i ? null : i));
+                        }}
+                    />
+                ))}
+            </Box>
+            {focusedSegment !== undefined && focused !== null && (
+                <GameDetail segment={focusedSegment} numbering={numbers[focused]} />
+            )}
+        </Panel>
+    );
+};
+
+interface TrajectoryChartProps {
+    session: NonNullable<SessionAt["session"]>;
+    segments: readonly GameSegment[];
+}
+
+const TrajectoryChart: React.FC<TrajectoryChartProps> = ({ session, segments }) => {
+    const theme = useTheme();
+    // NOTE: Assume the id format is CSS-selector-safe
+    const gradientId = `fkdr-fill-${React.useId()}`;
+    const points = fkdrTrajectory(session, segments);
+
+    if (points.length < 2) {
+        return (
+            <Panel sx={{ height: "100%" }}>
+                <Typography variant="subtitle1">FKDR trajectory</Typography>
+                <Typography variant="caption" color="textSecondary">
+                    Not enough games to draw a trajectory.
+                </Typography>
+            </Panel>
+        );
+    }
+
+    // Recharts wants a mutable array.
+    const data = [...points];
+    const primary = theme.palette.primary.main;
+    const lifetimeColor = theme.palette.text.secondary;
+
+    return (
+        <Panel sx={{ height: "100%" }}>
+            <Stack
+                direction="row"
+                justifyContent="space-between"
+                alignItems="baseline"
+                sx={{ mb: 1.5 }}
+                flexWrap="wrap"
+                gap={1}
+            >
+                <Box>
+                    <Typography variant="subtitle1">FKDR trajectory</Typography>
+                    <Typography variant="caption" color="textSecondary">
+                        Session FKDR after each game vs. all-time
+                    </Typography>
+                </Box>
+                <Stack direction="row" gap={1.75}>
+                    <Stack direction="row" alignItems="center" gap={0.75}>
+                        <Box
+                            sx={{
+                                width: 18,
+                                height: 2,
+                                bgcolor: primary,
+                                borderRadius: 1,
+                            }}
+                        />
+                        <Typography variant="caption" color="textSecondary">
+                            Session
+                        </Typography>
+                    </Stack>
+                    <Stack direction="row" alignItems="center" gap={0.75}>
+                        <Box
+                            sx={{
+                                width: 18,
+                                borderTop: `2px dashed ${lifetimeColor}`,
+                            }}
+                        />
+                        <Typography variant="caption" color="textSecondary">
+                            Lifetime
+                        </Typography>
+                    </Stack>
+                </Stack>
+            </Stack>
+            <Box sx={{ width: "100%", height: 240 }}>
+                <ComposedChart
+                    data={data}
+                    responsive
+                    width="100%"
+                    height="100%"
+                    style={{ minWidth: 100 }}
+                    margin={{ top: 8, right: 8, bottom: 0, left: 0 }}
+                >
+                    <defs>
+                        <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+                            <stop offset="0%" stopColor={primary} stopOpacity={0.32} />
+                            <stop offset="100%" stopColor={primary} stopOpacity={0} />
+                        </linearGradient>
+                    </defs>
+                    <CartesianGrid
+                        stroke={theme.palette.divider}
+                        strokeDasharray="2 4"
+                    />
+                    <XAxis
+                        dataKey="label"
+                        stroke={theme.palette.divider}
+                        tick={{ fill: theme.palette.text.secondary, fontSize: 12 }}
+                    />
+                    <YAxis
+                        domain={[0, "auto"]}
+                        stroke={theme.palette.divider}
+                        tick={{ fill: theme.palette.text.secondary, fontSize: 12 }}
+                        tickFormatter={(v: number) => v.toFixed(1)}
+                        width={40}
+                    />
+                    {/* Lifetime first so the session line + dots render on top. */}
+                    <Line
+                        name="Lifetime"
+                        type="monotone"
+                        dataKey="lifetimeFkdr"
+                        stroke={lifetimeColor}
+                        strokeWidth={1.5}
+                        strokeDasharray="4 4"
+                        dot={false}
+                        activeDot={false}
+                        isAnimationActive={false}
+                    />
+                    <Area
+                        name="Session"
+                        type="monotone"
+                        dataKey="sessionFkdr"
+                        stroke={primary}
+                        strokeWidth={2.5}
+                        fill={`url(#${gradientId})`}
+                        dot={{
+                            r: 4,
+                            fill: theme.palette.background.paper,
+                            stroke: primary,
+                            strokeWidth: 2,
+                        }}
+                        activeDot={{ r: 5 }}
+                        isAnimationActive={false}
+                    />
+                    <ChartTooltip
+                        labelFormatter={(label) =>
+                            typeof label === "string" ? label : ""
+                        }
+                        formatter={(value) =>
+                            typeof value === "number"
+                                ? formatStatValue("fkdr", value)
+                                : String(value)
+                        }
+                        contentStyle={{
+                            backgroundColor: theme.palette.background.paper,
+                            border: `1px solid ${theme.palette.divider}`,
+                            borderRadius: 8,
+                        }}
+                        itemStyle={{ color: theme.palette.text.primary }}
+                        labelStyle={{ color: theme.palette.text.secondary }}
+                    />
+                </ComposedChart>
+            </Box>
+        </Panel>
+    );
+};
+
+interface SessionMetaCardProps {
+    session: NonNullable<SessionAt["session"]>;
+    agg: SessionAggregate;
+}
+
+const SessionMetaCard: React.FC<SessionMetaCardProps> = ({ session, agg }) => {
+    const avgGameMs = agg.games > 0 ? agg.elapsedMs / agg.games : 0;
+    const items: [string, string][] = [
+        [
+            "Started",
+            session.start.queriedAt.toLocaleTimeString(undefined, {
+                timeStyle: "short",
+            }),
+        ],
+        [
+            "Ended",
+            session.end.queriedAt.toLocaleTimeString(undefined, {
+                timeStyle: "short",
+            }),
+        ],
+        ["Avg game", agg.games > 0 ? formatDuration(avgGameMs) : "—"],
+        ["Finals", `${agg.fk.toString()} / ${agg.fd.toString()}`],
+        ["Beds", `${agg.bb.toString()} / ${agg.bl.toString()}`],
+        ["XP", `+${agg.xp.toLocaleString()}`],
+    ];
+    return (
+        <Panel sx={{ height: "100%" }}>
+            <Typography variant="subtitle1" sx={{ mb: 1.75 }}>
+                Totals
+            </Typography>
+            <Box
+                sx={{
+                    display: "grid",
+                    gridTemplateColumns: "1fr 1fr",
+                    gap: 1.75,
+                }}
+            >
+                {items.map(([label, value]) => (
+                    <Box key={label}>
+                        <Typography
+                            variant="caption"
+                            color="textSecondary"
+                            sx={{ textTransform: "uppercase", letterSpacing: 0.6 }}
+                        >
+                            {label}
+                        </Typography>
+                        <Typography sx={{ fontFamily: "monospace", mt: 0.5 }}>
+                            {value}
+                        </Typography>
+                    </Box>
+                ))}
+            </Box>
+        </Panel>
+    );
+};
+
+const ModeDetail: React.FC<{
+    label: string;
+    stats: ModeStats;
+    color: string;
+}> = ({ label, stats, color }) => {
+    // Single-stat rows use the app's canonical short labels; the combined rows
+    // (a "X / Y" pair of two stats) keep bespoke headers.
+    const items: [string, string][] = [
+        [getShortStatLabel("gamesPlayed", true), stats.games.toString()],
+        ["Record", `${stats.wins.toString()}W · ${stats.losses.toString()}L`],
+        [getShortStatLabel("winrate", true), formatStatValue("winrate", stats.winRate)],
+        [getShortStatLabel("fkdr", true), formatStatValue("fkdr", stats.fkdr)],
+        ["Finals", `${stats.fk.toString()} / ${stats.fd.toString()}`],
+        ["Beds", `${stats.bb.toString()} / ${stats.bl.toString()}`],
+        ["Kills", `${stats.k.toString()} / ${stats.d.toString()}`],
+        [getShortStatLabel("kdr", true), formatStatValue("kdr", stats.kdr)],
+    ];
+    return (
+        <Box sx={{ mt: 1.75, pt: 1.75, borderTop: 1, borderColor: "divider" }}>
+            <Box
+                sx={{
+                    display: "grid",
+                    gridTemplateColumns: "repeat(4, 1fr)",
+                    gap: 1,
+                    maxWidth: 720,
+                    mx: "auto",
+                }}
+            >
+                <Stack
+                    direction="row"
+                    alignItems="center"
+                    gap={0.75}
+                    sx={{ gridColumn: "1 / -1", mb: 0.5 }}
+                >
+                    <Box
+                        sx={{ width: 8, height: 8, borderRadius: 0.25, bgcolor: color }}
+                    />
+                    <Typography
+                        variant="caption"
+                        color="textSecondary"
+                        sx={{
+                            textTransform: "uppercase",
+                            letterSpacing: 0.6,
+                            fontSize: 10,
+                        }}
+                    >
+                        {label}
+                    </Typography>
+                </Stack>
+                {items.map(([itemLabel, value]) => (
+                    <Box key={itemLabel}>
+                        <Typography
+                            variant="caption"
+                            color="textSecondary"
+                            sx={{
+                                textTransform: "uppercase",
+                                letterSpacing: 0.6,
+                                fontSize: 10,
+                            }}
+                        >
+                            {itemLabel}
+                        </Typography>
+                        <Typography
+                            sx={{ fontFamily: "monospace", fontSize: 14, mt: 0.5 }}
+                        >
+                            {value}
+                        </Typography>
+                    </Box>
+                ))}
+            </Box>
+        </Box>
+    );
+};
+
+const ModeBreakdown: React.FC<{
+    session: NonNullable<SessionAt["session"]>;
+}> = ({ session }) => {
+    const theme = useTheme();
+    const data = modeBreakdown(session);
+    const [expanded, setExpanded] = React.useState<ModeBreakdownKey | null>(null);
+
+    // The four original modes always show; the 4v4 tile and the "Other"
+    // bucket (Dreams modes) only appear when games were played in them.
+    const entries: {
+        key: ModeBreakdownKey;
+        label: string;
+        color: string;
+        stats: ModeStats;
+    }[] = GAMEMODES.filter((mode) => mode !== "4v4" || data[mode].games > 0).map(
+        (mode) => ({
+            key: mode,
+            label: getGamemodeLabel(mode, true),
+            color: theme.palette.gamemode[mode],
+            stats: data[mode],
+        }),
+    );
+    if (data.other.games > 0) {
+        entries.push({
+            key: "other",
+            label: "Other",
+            color: theme.palette.textMuted,
+            stats: data.other,
+        });
+    }
+    const expandedEntry = entries.find((entry) => entry.key === expanded);
+
+    return (
+        <Panel>
+            <Box sx={{ mb: 1.75 }}>
+                <Typography variant="subtitle1">By gamemode</Typography>
+                <Typography variant="caption" color="textSecondary">
+                    Click a mode for the full breakdown
+                </Typography>
+            </Box>
+            <Box
+                sx={{
+                    display: "grid",
+                    gridTemplateColumns: { xs: "repeat(2, 1fr)", sm: "repeat(4, 1fr)" },
+                    gap: 1.25,
+                }}
+            >
+                {entries.map(({ key, label, color, stats }) => {
+                    const empty = stats.games === 0;
+                    const active = expanded === key;
+                    return (
+                        <Button
+                            key={key}
+                            disabled={empty}
+                            onClick={() => {
+                                setExpanded((prev) => (prev === key ? null : key));
+                            }}
+                            aria-expanded={active}
+                            sx={{
+                                p: 1.75,
+                                borderRadius: 1.25,
+                                bgcolor: active ? alpha(color, 0.13) : "action.hover",
+                                border: 1,
+                                borderColor: active ? color : "divider",
+                                color: "text.primary",
+                                textTransform: "none",
+                                textAlign: "left",
+                                flexDirection: "column",
+                                alignItems: "stretch",
+                                minWidth: 0,
+                                opacity: empty ? 0.4 : 1,
+                                "&:hover": { bgcolor: alpha(color, 0.07) },
+                            }}
+                        >
+                            <Stack
+                                direction="row"
+                                alignItems="center"
+                                gap={0.75}
+                                sx={{ mb: 1.25 }}
+                            >
+                                <Box
+                                    sx={{
+                                        width: 8,
+                                        height: 8,
+                                        borderRadius: 0.25,
+                                        bgcolor: color,
+                                    }}
+                                />
+                                <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                                    {label}
+                                </Typography>
+                                {key === "other" && (
+                                    <Tooltip title="Games played in modes that aren't broken out individually, such as a Dreams mode.">
+                                        <Help
+                                            sx={{
+                                                fontSize: 14,
+                                                color: "text.disabled",
+                                                ml: "auto",
+                                            }}
+                                        />
+                                    </Tooltip>
+                                )}
+                            </Stack>
+                            <Typography sx={{ fontSize: 22, lineHeight: 1.1 }}>
+                                {stats.games.toString()}
+                            </Typography>
+                            <Typography variant="caption" color="textSecondary">
+                                {`games · ${stats.wins.toString()}W`}
+                            </Typography>
+                            <LinearProgress
+                                variant="determinate"
+                                value={stats.winRate * 100}
+                                sx={{
+                                    mt: 1.5,
+                                    height: 4,
+                                    borderRadius: 1,
+                                    bgcolor: "divider",
+                                    "& .MuiLinearProgress-bar": { bgcolor: color },
+                                }}
+                            />
+                            <Stack
+                                direction="row"
+                                justifyContent="space-between"
+                                sx={{ mt: 1 }}
+                            >
+                                <Typography variant="caption" color="textSecondary">
+                                    FKDR
+                                </Typography>
+                                <Typography
+                                    variant="caption"
+                                    sx={{ fontFamily: "monospace" }}
+                                >
+                                    {formatStatValue("fkdr", stats.fkdr)}
+                                </Typography>
+                            </Stack>
+                        </Button>
+                    );
+                })}
+            </Box>
+            {expandedEntry !== undefined && (
+                <ModeDetail
+                    label={expandedEntry.label}
+                    stats={expandedEntry.stats}
+                    color={expandedEntry.color}
+                />
+            )}
+        </Panel>
+    );
+};
+
+const MilestonesCard: React.FC<{ milestones: readonly Milestone[] }> = ({
+    milestones,
+}) => {
+    const theme = useTheme();
+    return (
+        <Panel>
+            <Typography variant="subtitle1">Milestones</Typography>
+            <Typography variant="caption" color="textSecondary" sx={{ mb: 1.75 }}>
+                At this session&apos;s pace
+            </Typography>
+            <Box
+                sx={{
+                    mt: 1.75,
+                    display: "grid",
+                    gridTemplateColumns: { xs: "1fr", sm: "repeat(3, 1fr)" },
+                    gap: 1.25,
+                }}
+            >
+                {milestones.map((m) => {
+                    const Icon = MILESTONE_ICONS[m.key];
+                    const color = milestoneColor(theme, m.key);
+                    const reachable = m.target !== null && Number.isFinite(m.sessions);
+                    // Stars and wins only ever climb (green, up); FKDR is
+                    // session-dependent, so an underperforming session projects a
+                    // lower target, surfaced via getTrendSentiment as a red
+                    // down-trend — matching the regular session page.
+                    const trend =
+                        m.target === null
+                            ? "flat"
+                            : getTrendDirection(m.current, m.target);
+                    const trendSentiment = getTrendSentiment(
+                        MILESTONE_STAT[m.key],
+                        trend,
+                    );
+                    return (
+                        <Box
+                            key={m.key}
+                            sx={{
+                                bgcolor: "action.hover",
+                                border: 1,
+                                borderColor: "divider",
+                                borderRadius: 1.25,
+                                p: 2,
+                                display: "flex",
+                                flexDirection: "column",
+                                gap: 1.25,
+                            }}
+                        >
+                            <Stack direction="row" alignItems="center" gap={1}>
+                                <Box
+                                    sx={{
+                                        width: 28,
+                                        height: 28,
+                                        borderRadius: 0.875,
+                                        bgcolor: alpha(color, 0.12),
+                                        display: "flex",
+                                        alignItems: "center",
+                                        justifyContent: "center",
+                                    }}
+                                >
+                                    <Icon sx={{ fontSize: 16, color }} />
+                                </Box>
+                                <Typography
+                                    variant="caption"
+                                    color="textSecondary"
+                                    sx={{
+                                        textTransform: "uppercase",
+                                        letterSpacing: 0.6,
+                                    }}
+                                >
+                                    {m.label}
+                                </Typography>
+                            </Stack>
+                            <Stack
+                                direction="row"
+                                alignItems="baseline"
+                                gap={1}
+                                sx={{ fontFamily: "monospace" }}
+                            >
+                                <Typography sx={{ fontSize: 18 }}>
+                                    {m.format(m.current)}
+                                </Typography>
+                                <TrendIcon
+                                    direction={trend}
+                                    sx={{
+                                        fontSize: 16,
+                                        color: SENTIMENT_COLOR[trendSentiment],
+                                    }}
+                                />
+                                <Typography sx={{ fontSize: 18, color }}>
+                                    {m.target === null ? "—" : m.format(m.target)}
+                                </Typography>
+                            </Stack>
+                            {reachable ? (
+                                <Box>
+                                    <Stack
+                                        direction="row"
+                                        alignItems="baseline"
+                                        gap={0.75}
+                                    >
+                                        <Typography
+                                            sx={{ fontSize: 26, lineHeight: 1 }}
+                                        >
+                                            {m.sessions < 1
+                                                ? "This session"
+                                                : Math.ceil(m.sessions).toString()}
+                                        </Typography>
+                                        {m.sessions >= 1 && (
+                                            <Typography
+                                                variant="caption"
+                                                color="textSecondary"
+                                            >
+                                                {`session${Math.ceil(m.sessions) === 1 ? "" : "s"} like this`}
+                                            </Typography>
+                                        )}
+                                    </Stack>
+                                    {m.sessions >= 1 && (
+                                        <Stack
+                                            direction="row"
+                                            gap={0.5}
+                                            alignItems="center"
+                                            sx={{ mt: 0.75 }}
+                                        >
+                                            <Schedule
+                                                sx={{
+                                                    fontSize: 12,
+                                                    color: "text.disabled",
+                                                }}
+                                            />
+                                            <Typography
+                                                variant="caption"
+                                                color="textSecondary"
+                                                sx={{ fontFamily: "monospace" }}
+                                            >
+                                                {`≈ ${formatDuration(m.playtimeMs)} of playtime`}
+                                            </Typography>
+                                        </Stack>
+                                    )}
+                                </Box>
+                            ) : (
+                                <Stack
+                                    direction="row"
+                                    alignItems="center"
+                                    gap={0.75}
+                                    color="text.disabled"
+                                >
+                                    <Block fontSize="small" />
+                                    <Typography variant="caption">
+                                        {m.blockedReason ?? "Not on pace to reach this"}
+                                    </Typography>
+                                </Stack>
+                            )}
+                            <Typography
+                                variant="caption"
+                                color="textSecondary"
+                                sx={{ fontFamily: "monospace" }}
+                            >
+                                {m.deltaFormat()}
+                            </Typography>
+                        </Box>
+                    );
+                })}
+            </Box>
+        </Panel>
+    );
+};
+
+interface HighlightItem {
+    readonly id: string;
+    readonly icon: SvgIconComponent;
+    readonly color: string;
+    readonly title: string;
+    readonly value: string;
+    readonly sub: string;
+}
+
+const HighlightsCard: React.FC<{
+    agg: SessionAggregate;
+    segments: readonly GameSegment[];
+}> = ({ agg, segments }) => {
+    const theme = useTheme();
+    const best = bestGame(segments);
+    const fastest = fastestWin(segments);
+    const hours = agg.elapsedMs / MS_PER_HOUR;
+
+    // Classify session FKDR against lifetime (±10% band; see fkdrVsLifetime).
+    const vsLifetime: { icon: SvgIconComponent; color: string; title: string } = {
+        beating: {
+            icon: TrendingUp,
+            color: theme.palette.success.main,
+            title: "FKDR beating lifetime",
+        },
+        below: {
+            icon: TrendingDown,
+            color: theme.palette.error.main,
+            title: "FKDR below lifetime",
+        },
+        on_par: {
+            icon: TrendingFlat,
+            color: theme.palette.text.secondary,
+            title: "FKDR on par with lifetime",
+        },
+    }[fkdrVsLifetime(agg)];
+
+    // Number games by running game count so these labels match the momentum
+    // strip and the trajectory chart (e.g. the 2nd win after a gap is G2, not G3).
+    const numbers = segmentGameNumbers(segments);
+    const bestIndex = best === undefined ? -1 : segments.indexOf(best);
+    const fastestIndex = fastest === undefined ? -1 : segments.indexOf(fastest);
+    const bestLabel = bestIndex === -1 ? null : gameNumberLabel(numbers[bestIndex]);
+    const fastestLabel =
+        fastestIndex === -1 ? null : gameNumberLabel(numbers[fastestIndex]);
+
+    const items: readonly HighlightItem[] = [
+        {
+            id: "signature",
+            icon: WorkspacePremium,
+            color: theme.palette.warning.main,
+            title: "Best game",
+            value:
+                best === undefined || bestLabel === null
+                    ? "—"
+                    : `${bestLabel} · ${best.game.finalKills.toString()} finals`,
+            sub:
+                best === undefined
+                    ? "No single-game segments"
+                    : `${best.game.kills.toString()} kills · ${getGamemodeLabel(best.game.gamemode, true)}`,
+        },
+        {
+            id: "fastest",
+            icon: Bolt,
+            color: theme.palette.success.main,
+            title: "Fastest win",
+            value:
+                fastest === undefined
+                    ? "—"
+                    : `${Math.max(1, Math.round(segmentDurationMs(fastest) / MS_PER_MINUTE)).toString()}m`,
+            sub:
+                fastest === undefined || fastestLabel === null
+                    ? "No wins yet"
+                    : `${fastestLabel} · ${getGamemodeLabel(fastest.game.gamemode, true)}`,
+        },
+        {
+            id: "vs-lifetime",
+            icon: vsLifetime.icon,
+            color: vsLifetime.color,
+            title: vsLifetime.title,
+            value: formatStatValue("fkdr", agg.fkdr),
+            sub: `vs ${formatStatValue("fkdr", agg.lifetimeFkdr)} all-time`,
+        },
+        {
+            id: "pace",
+            icon: Speed,
+            color: theme.palette.secondary.main,
+            title: "Pace",
+            value: hours > 0 ? `${(agg.fk / hours).toFixed(1)} fk/hr` : "—",
+            sub: hours > 0 ? `${(agg.games / hours).toFixed(1)} games/hr` : "",
+        },
+    ];
+
+    return (
+        <Panel>
+            <Typography variant="subtitle1" sx={{ mb: 1.75 }}>
+                Highlights
+            </Typography>
+            <Box
+                sx={{
+                    display: "grid",
+                    gridTemplateColumns: { xs: "repeat(2, 1fr)", sm: "repeat(4, 1fr)" },
+                    gap: 1.25,
+                }}
+            >
+                {items.map((h) => (
+                    <Box
+                        key={h.id}
+                        sx={{
+                            bgcolor: "action.hover",
+                            border: 1,
+                            borderColor: "divider",
+                            borderRadius: 1.25,
+                            p: 1.75,
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: 0.75,
+                        }}
+                    >
+                        <Box
+                            sx={{
+                                width: 32,
+                                height: 32,
+                                borderRadius: 1,
+                                bgcolor: alpha(h.color, 0.12),
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "center",
+                                mb: 0.5,
+                            }}
+                        >
+                            <h.icon sx={{ fontSize: 18, color: h.color }} />
+                        </Box>
+                        <Typography
+                            variant="caption"
+                            color="textSecondary"
+                            sx={{ textTransform: "uppercase", letterSpacing: 0.6 }}
+                        >
+                            {h.title}
+                        </Typography>
+                        <Typography
+                            sx={{ fontSize: 18, fontWeight: 500, lineHeight: 1.1 }}
+                        >
+                            {h.value}
+                        </Typography>
+                        <Typography variant="caption" color="textSecondary">
+                            {h.sub}
+                        </Typography>
+                    </Box>
+                ))}
+            </Box>
+        </Panel>
+    );
+};
+
+interface SessionDetailProps {
+    data: SessionAt;
+    uuid: string;
+    username: string | undefined;
+    onShare: () => void;
+}
+
+const SessionDetail: React.FC<SessionDetailProps> = ({
+    data,
+    uuid,
+    username,
+    onShare,
+}) => {
+    if (data.session === null) return null;
+    const { session, games } = data;
+    const agg = aggregate(session);
+    const tags = computeTags(agg);
+    const milestones = computeMilestones(session, agg);
+
+    const displayName = username ?? "Player";
+
+    return (
+        <Stack spacing={2}>
+            <PlayerBanner
+                uuid={uuid}
+                username={displayName}
+                session={session}
+                agg={agg}
+                onShare={onShare}
+            />
+            {tags.length > 0 && <TagsRow tags={tags} />}
+            <KPIRow agg={agg} />
+            {games.length > 0 && <MomentumStrip segments={games} />}
+            <Stack
+                direction={{ xs: "column", md: "row" }}
+                gap={1.5}
+                alignItems="stretch"
+            >
+                <Box sx={{ flex: 2, minWidth: 0 }}>
+                    <TrajectoryChart session={session} segments={games} />
+                </Box>
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <SessionMetaCard session={session} agg={agg} />
+                </Box>
+            </Stack>
+            <ModeBreakdown session={session} />
+            <MilestonesCard milestones={milestones} />
+            <HighlightsCard agg={agg} segments={games} />
+        </Stack>
+    );
+};
+
+function RouteComponent() {
+    const { uuid: rawUUID } = Route.useParams();
+    const { date } = Route.useSearch();
+    const navigate = Route.useNavigate();
+    const queryClient = useQueryClient();
+
+    const uuid = normalizeUUID(rawUUID);
+
+    const { data, isFetching, isError } = useQuery({
+        ...getSessionAtQueryOptions({
+            uuid: uuid ?? "",
+            time: date,
+        }),
+        enabled: uuid !== null,
+    });
+
+    const uuidToUsername = useUUIDToUsername(uuid !== null ? [uuid] : []);
+    const username = uuid !== null ? uuidToUsername[uuid] : undefined;
+
+    const [snackbarOpen, setSnackbarOpen] = React.useState(false);
+
+    // Normalize the URL date to the session's actual start time so the
+    // URL is canonical and shareable. Pre-seed the cache for the
+    // canonical query key to avoid a duplicate fetch after navigate.
+    const sessionStart = data?.session?.start.queriedAt;
+    React.useEffect(() => {
+        if (sessionStart === undefined) return;
+        if (uuid === null) return;
+        if (sessionStart.getTime() === date.getTime()) return;
+        const run = async () => {
+            try {
+                queryClient.setQueryData(
+                    getSessionAtQueryOptions({ uuid, time: sessionStart }).queryKey,
+                    data,
+                );
+                await navigate({
+                    replace: true,
+                    search: (old) => ({ ...old, date: sessionStart }),
+                });
+            } catch (error: unknown) {
+                captureException(error, {
+                    tags: { param: "date" },
+                    extra: { message: "Failed to normalize session detail URL" },
+                });
+            }
+        };
+        void run();
+    }, [sessionStart, date, navigate, queryClient, uuid, data]);
+
+    if (uuid === null) {
+        return <Navigate to="/session" replace />;
+    }
+
+    if (uuid !== rawUUID) {
+        return (
+            <Navigate
+                from="/session/$uuid/detail"
+                to="/session/$uuid/detail"
+                replace
+                params={{ uuid }}
+                search={(old) => ({ ...old, date })}
+            />
+        );
+    }
+
+    const handleShare = () => {
+        const url = globalThis.location.href;
+        const run = async () => {
+            try {
+                await navigator.clipboard.writeText(url);
+                setSnackbarOpen(true);
+            } catch (error: unknown) {
+                captureException(error, {
+                    extra: { message: "Failed to copy share link" },
+                });
+            }
+        };
+        void run();
+    };
+
+    const displayName = username ?? "Player";
+
+    return (
+        <Stack spacing={2}>
+            <meta
+                name="description"
+                content={`${displayName}'s Bedwars session detail.`}
+            />
+            {isFetching && data === undefined && (
+                <Skeleton variant="rounded" height={140} />
+            )}
+            {isError && !isFetching && (
+                <Alert severity="error">Failed to load session.</Alert>
+            )}
+            {!isFetching && data !== undefined && data.session === null && (
+                <NoSession username={displayName} />
+            )}
+            {data !== undefined && data.session !== null && (
+                <SessionDetail
+                    data={data}
+                    uuid={uuid}
+                    username={username}
+                    onShare={handleShare}
+                />
+            )}
+            <Snackbar
+                open={snackbarOpen}
+                autoHideDuration={2500}
+                onClose={() => {
+                    setSnackbarOpen(false);
+                }}
+                anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+            >
+                <Alert
+                    severity="success"
+                    variant="filled"
+                    icon={<ContentCopy fontSize="small" />}
+                    sx={{ width: "100%" }}
+                >
+                    Link copied!
+                </Alert>
+            </Snackbar>
+        </Stack>
+    );
+}

--- a/src/routes/session/-uuid_.detail.ui.test.tsx
+++ b/src/routes/session/-uuid_.detail.ui.test.tsx
@@ -1,0 +1,102 @@
+import { http, HttpResponse } from "msw";
+import type { SetupWorker } from "msw/browser";
+import { describe, expect } from "vitest";
+
+import { USERS } from "#mocks/data.ts";
+import { mswTest } from "#test/msw-test.ts";
+import { renderAppRoute } from "#test/render.tsx";
+
+describe("Session detail page", () => {
+    const date = "2025-11-03T22:00:00.000Z";
+    const detailUrl = `/session/${USERS.player1.uuid}/detail?date=${encodeURIComponent(date)}`;
+
+    mswTest("renders the player banner heading with the username", async () => {
+        const { screen } = await renderAppRoute(detailUrl);
+
+        await expect
+            .element(screen.getByRole("heading", { name: USERS.player1.username }))
+            .toBeInTheDocument();
+    });
+
+    mswTest("renders the share button", async () => {
+        const { screen } = await renderAppRoute(detailUrl);
+
+        await expect
+            .element(screen.getByRole("button", { name: "Share" }))
+            .toBeInTheDocument();
+    });
+
+    mswTest("renders the KPI row labels", async () => {
+        const { screen } = await renderAppRoute(detailUrl);
+
+        // `exact` so "Session FKDR" doesn't also match the chart's
+        // "Session FKDR after each game …" subtitle.
+        await expect
+            .element(screen.getByText("Win rate", { exact: true }))
+            .toBeInTheDocument();
+        await expect
+            .element(screen.getByText("Session FKDR", { exact: true }))
+            .toBeInTheDocument();
+        await expect
+            .element(screen.getByText("Stars gained", { exact: true }))
+            .toBeInTheDocument();
+    });
+
+    mswTest("renders the main section cards", async () => {
+        const { screen } = await renderAppRoute(detailUrl);
+
+        await expect.element(screen.getByText("Game-by-game")).toBeInTheDocument();
+        await expect.element(screen.getByText("FKDR trajectory")).toBeInTheDocument();
+        await expect.element(screen.getByText("By gamemode")).toBeInTheDocument();
+        await expect.element(screen.getByText("Milestones")).toBeInTheDocument();
+        await expect.element(screen.getByText("Highlights")).toBeInTheDocument();
+    });
+
+    mswTest("normalizes the URL date to the session start", async () => {
+        // The mock session-at handler starts the session an hour before the
+        // requested time; the page rewrites `date` to that canonical start.
+        await renderAppRoute(detailUrl);
+
+        await expect
+            .poll(() => {
+                const param = new URLSearchParams(globalThis.location.search).get(
+                    "date",
+                );
+                return param !== null && param !== date;
+            })
+            .toBe(true);
+    });
+
+    mswTest("expands a game tile into its detail row on click", async () => {
+        const { screen } = await renderAppRoute(detailUrl);
+
+        // Wait for the momentum strip to render, then click the first game tile.
+        // `.first()` disambiguates it from the identically-labelled chart axis
+        // tick, which renders later in the DOM.
+        const tile = screen.getByText("G1").first();
+        await expect.element(tile).toBeInTheDocument();
+        await tile.click();
+
+        // The expanded detail row shows a per-game stat grid whose "FINAL KILLS"
+        // label appears nowhere else on the page (the tile now shares the "G1"
+        // label with the detail title, so assert on a detail-only element).
+        await expect.element(screen.getByText("FINAL KILLS")).toBeInTheDocument();
+    });
+
+    mswTest(
+        "shows the no-session empty state when session-at returns null",
+        async ({ worker }: { readonly worker: SetupWorker }) => {
+            worker.use(
+                http.post("http://localhost:5173/flashlight/v1/session-at", () => {
+                    return HttpResponse.json({ session: null, games: [] });
+                }),
+            );
+
+            const { screen } = await renderAppRoute(detailUrl);
+
+            await expect
+                .element(screen.getByText("No session yet"))
+                .toBeInTheDocument();
+        },
+    );
+});

--- a/src/schemas/detailSearch.ts
+++ b/src/schemas/detailSearch.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+// Fall back to the current time for a missing or malformed date so a shared or
+// hand-edited link degrades to the NoSession view rather than tripping the
+// router's error boundary. In-app links always pass a valid date.
+//
+// `now` is injected so tests can pin "current time" deterministically. The real
+// dependency is bound in the singleton export below, so consumers stay
+// unchanged. The fallbacks are thunks so "now" is recomputed on every parse
+// rather than frozen at module-eval time.
+export const makeDetailSearchSchema = (now: () => Date = () => new Date()) =>
+    z.object({
+        date: z.coerce
+            .date()
+            .catch(() => now())
+            .default(() => now()),
+    });
+
+export const detailSearchSchema = makeDetailSearchSchema();

--- a/src/schemas/detailSearch.unit.test.ts
+++ b/src/schemas/detailSearch.unit.test.ts
@@ -1,0 +1,36 @@
+import { test, expect, describe } from "vitest";
+
+import { makeDetailSearchSchema } from "./detailSearch.ts";
+
+// Pin "now" so fallbacks are deterministic instead of drifting with the
+// wall-clock. Tests assert against this exact instant.
+const NOW = new Date("2025-06-15T12:34:56.789Z");
+const detailSearchSchema = makeDetailSearchSchema(() => NOW);
+
+describe("detailSearchSchema validation", () => {
+    test("valid date string is coerced to a Date", () => {
+        const result = detailSearchSchema.parse({
+            date: "2025-11-03T22:59:59.999Z",
+        });
+        expect(result.date).toStrictEqual(new Date("2025-11-03T22:59:59.999Z"));
+    });
+
+    test("date coercion understands simple date strings", () => {
+        // NOTE: These should be UTC dates with timezone in production
+        const result = detailSearchSchema.parse({ date: "2024-01-15" });
+
+        expect(result.date.getFullYear()).toBe(2024);
+        expect(result.date.getMonth()).toBe(0);
+        expect(result.date.getDate()).toBe(15);
+    });
+
+    test("missing date -> falls back to the injected current time", () => {
+        const result = detailSearchSchema.parse({});
+        expect(result.date).toStrictEqual(NOW);
+    });
+
+    test("malformed date -> falls back to the injected current time", () => {
+        const result = detailSearchSchema.parse({ date: "not-a-date" });
+        expect(result.date).toStrictEqual(NOW);
+    });
+});

--- a/src/stats/keys.ts
+++ b/src/stats/keys.ts
@@ -27,14 +27,18 @@ export type GamemodeStatKey = (typeof GAMEMODE_STAT_KEYS)[number];
 export const ALL_STAT_KEYS = [...OVERALL_STAT_KEYS, ...GAMEMODE_STAT_KEYS] as const;
 export type StatKey = (typeof ALL_STAT_KEYS)[number];
 
-export const ALL_GAMEMODE_KEYS = [
+// The real gamemodes, in display order. `overall` is the cross-mode aggregate
+// and is intentionally not one of these — keep it the single source of truth for
+// the mode list so a new mode is added in exactly one place.
+export const REAL_GAMEMODE_KEYS = [
     "solo",
     "doubles",
     "threes",
     "fours",
     "4v4",
-    "overall",
 ] as const;
+
+export const ALL_GAMEMODE_KEYS = [...REAL_GAMEMODE_KEYS, "overall"] as const;
 export type GamemodeKey = (typeof ALL_GAMEMODE_KEYS)[number];
 
 export const ALL_VARIANT_KEYS = ["session", "overall"] as const;

--- a/src/stats/progression.ts
+++ b/src/stats/progression.ts
@@ -110,6 +110,26 @@ const nextRoundNumberMilestone = (value: number, trendingUpward: boolean): numbe
     return Math.floor(adjusted / magnitude) * magnitude;
 };
 
+/*
+ * Next "half-decade" number above (or below) `value`: the value's order of
+ * magnitude split into halves (…, 1000, 1500, 2000, 2500, …) — half the step of
+ * `nextRoundNumberMilestone`, so counter milestones land closer. The step is
+ * floored at 1 so integer counters never get a fractional target, and (like the
+ * round-number default) going down at an exact rung drops below it.
+ */
+const nextHalfDecadeMilestone = (value: number, trendingUpward: boolean): number => {
+    if (value <= 0) {
+        return 1;
+    }
+    if (trendingUpward) {
+        const step = Math.max(1, 10 ** Math.floor(Math.log10(value)) / 2);
+        return (Math.floor(value / step) + 1) * step;
+    }
+    const adjusted = value * (1 - 1e-9);
+    const step = Math.max(1, 10 ** Math.floor(Math.log10(adjusted)) / 2);
+    return Math.floor(adjusted / step) * step;
+};
+
 /**
  * Picks the next milestone target for `stat` at its current `value`, given the
  * direction it is trending.
@@ -168,6 +188,32 @@ export const nextNaturalMilestone: MilestoneStrategy = (
         }
         default: {
             return nextRoundNumberMilestone(value, trendingUpward);
+        }
+    }
+};
+
+/*
+ * A tighter milestone strategy that always lands closer than
+ * `nextNaturalMilestone`, used by the session detail page so its "X sessions
+ * like this" goals feel reachable: the next tenth-of-a-prestige for stars, the
+ * next 0.5 for ratios, and the next half-decade (order of magnitude split in
+ * half) for every other counter.
+ */
+export const nextCloseMilestone: MilestoneStrategy = (value, trendingUpward, stat) => {
+    switch (stat) {
+        case "stars": {
+            // Next multiple of 10 (a tenth of a prestige). Stars only trend up.
+            return (Math.floor(value / 10) + 1) * 10;
+        }
+        case "fkdr":
+        case "kdr": {
+            // Next 0.5 step in the trend direction.
+            return trendingUpward
+                ? (Math.floor(value / 0.5) + 1) * 0.5
+                : (Math.ceil(value / 0.5) - 1) * 0.5;
+        }
+        default: {
+            return nextHalfDecadeMilestone(value, trendingUpward);
         }
     }
 };

--- a/src/stats/progression.unit.test.ts
+++ b/src/stats/progression.unit.test.ts
@@ -10,6 +10,7 @@ import {
     ERR_NO_DATA,
     ERR_TRACKING_STARTED,
     findSmallestPositiveCubicRoot,
+    nextCloseMilestone,
     nextNaturalMilestone,
 } from "./progression.ts";
 import type { MilestoneStrategy } from "./progression.ts";
@@ -2548,6 +2549,265 @@ describe(nextNaturalMilestone, () => {
         for (const { value, stat } of samples) {
             expect(nextNaturalMilestone(value, true, stat)).toBeGreaterThan(value);
             expect(nextNaturalMilestone(value, false, stat)).toBeLessThan(value);
+        }
+    });
+});
+
+describe(nextCloseMilestone, () => {
+    const cases: {
+        name: string;
+        value: number;
+        trendingUpward: boolean;
+        stat: StatKey;
+        expected: number;
+    }[] = [
+        // Stars: next multiple of 10 (a tenth of a prestige), regardless of trend.
+        {
+            name: "stars: low value",
+            value: 4,
+            trendingUpward: true,
+            stat: "stars",
+            expected: 10,
+        },
+        {
+            name: "stars: 42 -> 50",
+            value: 42,
+            trendingUpward: true,
+            stat: "stars",
+            expected: 50,
+        },
+        {
+            name: "stars: mid prestige",
+            value: 156,
+            trendingUpward: true,
+            stat: "stars",
+            expected: 160,
+        },
+        {
+            name: "stars: high, near a prestige",
+            value: 887,
+            trendingUpward: true,
+            stat: "stars",
+            expected: 890,
+        },
+        {
+            name: "stars: exactly on a multiple of ten",
+            value: 40,
+            trendingUpward: true,
+            stat: "stars",
+            expected: 50,
+        },
+        {
+            name: "stars: zero",
+            value: 0,
+            trendingUpward: true,
+            stat: "stars",
+            expected: 10,
+        },
+
+        // Quotients (fkdr/kdr): next 0.5 step in the trend direction.
+        {
+            name: "fkdr: up from fractional",
+            value: 200 / 75,
+            trendingUpward: true,
+            stat: "fkdr",
+            expected: 3,
+        },
+        {
+            name: "fkdr: up 2.73 -> 3.0",
+            value: 2.73,
+            trendingUpward: true,
+            stat: "fkdr",
+            expected: 3,
+        },
+        {
+            name: "fkdr: up 5.2 -> 5.5",
+            value: 5.2,
+            trendingUpward: true,
+            stat: "fkdr",
+            expected: 5.5,
+        },
+        {
+            name: "fkdr: up 1.4 -> 1.5",
+            value: 1.4,
+            trendingUpward: true,
+            stat: "fkdr",
+            expected: 1.5,
+        },
+        {
+            name: "fkdr: up from exact half-step",
+            value: 2.5,
+            trendingUpward: true,
+            stat: "fkdr",
+            expected: 3,
+        },
+        {
+            name: "fkdr: up from exact integer",
+            value: 5,
+            trendingUpward: true,
+            stat: "fkdr",
+            expected: 5.5,
+        },
+        {
+            name: "kdr: up from below 1",
+            value: 0.5,
+            trendingUpward: true,
+            stat: "kdr",
+            expected: 1,
+        },
+        {
+            name: "fkdr: down from fractional",
+            value: 2.73,
+            trendingUpward: false,
+            stat: "fkdr",
+            expected: 2.5,
+        },
+        {
+            name: "fkdr: down from exact integer",
+            value: 2,
+            trendingUpward: false,
+            stat: "fkdr",
+            expected: 1.5,
+        },
+        {
+            name: "kdr: down from exact half-step",
+            value: 2.5,
+            trendingUpward: false,
+            stat: "kdr",
+            expected: 2,
+        },
+        {
+            name: "fkdr: down to a whole number",
+            value: 1.2,
+            trendingUpward: false,
+            stat: "fkdr",
+            expected: 1,
+        },
+
+        // Everything else: half-decade step (magnitude / 2), floored at 1.
+        {
+            name: "wins: 90 -> 95",
+            value: 90,
+            trendingUpward: true,
+            stat: "wins",
+            expected: 95,
+        },
+        {
+            name: "wins: 200 -> 250",
+            value: 200,
+            trendingUpward: true,
+            stat: "wins",
+            expected: 250,
+        },
+        {
+            name: "wins: 1200 -> 1500",
+            value: 1200,
+            trendingUpward: true,
+            stat: "wins",
+            expected: 1500,
+        },
+        {
+            name: "wins: 4200 -> 4500",
+            value: 4200,
+            trendingUpward: true,
+            stat: "wins",
+            expected: 4500,
+        },
+        {
+            name: "finalKills: 12000 -> 15000",
+            value: 12_000,
+            trendingUpward: true,
+            stat: "finalKills",
+            expected: 15_000,
+        },
+        {
+            name: "experience: 7000 -> 7500",
+            value: 7000,
+            trendingUpward: true,
+            stat: "experience",
+            expected: 7500,
+        },
+        {
+            name: "index: up small",
+            value: 16,
+            trendingUpward: true,
+            stat: "index",
+            expected: 20,
+        },
+        {
+            name: "wins: single digit steps by 1 (no fractional target)",
+            value: 3,
+            trendingUpward: true,
+            stat: "wins",
+            expected: 4,
+        },
+        // Going down uses the same half-decade step; the epsilon nudge keeps a
+        // value sitting exactly on a rung from returning itself.
+        {
+            name: "index: down at power of ten",
+            value: 100,
+            trendingUpward: false,
+            stat: "index",
+            expected: 95,
+        },
+        {
+            name: "index: down within a decade",
+            value: 250,
+            trendingUpward: false,
+            stat: "index",
+            expected: 200,
+        },
+        // Non-positive values clamp to 1 (no order of magnitude to scale to).
+        {
+            name: "index: zero up",
+            value: 0,
+            trendingUpward: true,
+            stat: "index",
+            expected: 1,
+        },
+        {
+            name: "wins: negative up",
+            value: -5,
+            trendingUpward: true,
+            stat: "wins",
+            expected: 1,
+        },
+    ];
+
+    for (const c of cases) {
+        test(c.name, () => {
+            expect(nextCloseMilestone(c.value, c.trendingUpward, c.stat)).toBe(
+                c.expected,
+            );
+        });
+    }
+
+    test("honors the strict-monotonic contract for representative inputs", () => {
+        const samples: { value: number; stat: StatKey }[] = [
+            { value: 3.5, stat: "fkdr" },
+            { value: 4, stat: "kdr" },
+            { value: 16, stat: "index" },
+            { value: 100, stat: "wins" },
+            { value: 250, stat: "experience" },
+        ];
+        for (const { value, stat } of samples) {
+            expect(nextCloseMilestone(value, true, stat)).toBeGreaterThan(value);
+            expect(nextCloseMilestone(value, false, stat)).toBeLessThan(value);
+        }
+    });
+
+    test("always lands strictly closer than the natural milestone (upward)", () => {
+        const samples: { value: number; stat: StatKey }[] = [
+            { value: 42, stat: "stars" },
+            { value: 1200, stat: "wins" },
+            { value: 12_000, stat: "finalKills" },
+            { value: 5.2, stat: "fkdr" },
+        ];
+        for (const { value, stat } of samples) {
+            const close = nextCloseMilestone(value, true, stat);
+            const natural = nextNaturalMilestone(value, true, stat);
+            expect(close).toBeGreaterThan(value);
+            expect(close).toBeLessThanOrEqual(natural);
         }
     });
 });


### PR DESCRIPTION
## Summary

A shareable, read-only **session detail page** at `/session/$uuid/detail?date=<ISO>`, plus the stats-layer groundwork it needs. It loads a single session from the new flashlight `POST /v1/session-at` endpoint and renders a full breakdown of that one session, adapted from the design handoff (`design/project/Current Session.html`) but mapped onto MUI while keeping the design's accent colours / rainbow ribbon.

## What's on the page

- **Player banner** — face avatar, prestige star chip, live/ended badge, started/ended/duration, games count, Share button.
- **Tags row** — auto-derived from the aggregate: Flawless, Perfect run, On fire, Marathon.
- **KPI row** — Games (W/L), Win rate (Δ vs lifetime), Session FKDR (Δ vs lifetime), Stars gained.
- **Momentum strip** — a tile per game with finals, mode dot, minutes, and a W/L/D badge; click to expand a Finals/Beds/Kills/XP detail row with status/accolade chips (Perfect game / Carried / Clutch, Survived / Final death, Bed kept / Bed lost). A trailing-streak indicator sits in the header.
- **FKDR trajectory** — Recharts line: cumulative session FKDR vs a *live* lifetime baseline after each game.
- **Totals** — started/ended/avg game, finals, beds, XP.
- **Mode breakdown** — solo/doubles/threes/fours/4v4 cards with games, wins, a win-rate bar, and FKDR; click to expand. The 4v4 card and the **"Other"** bucket (Dreams modes folded into `overall`) render only when games were played in them.
- **Milestones** — next stars / next wins / next FKDR, each with "X sessions like this" and projected playtime.
- **Highlights** — best game, fastest win, session-vs-lifetime FKDR (beating / on par / below), and pace (fk/hr · games/hr).

## Data model & derivation

- **`src/queries/sessionAt.ts`** — typed client for `POST /v1/session-at`, returning `{ session, games }`. Each entry in `games` is a `GameSegment` `{ start, end, game }` where `game` is `null` for a no-game window or an unsplittable multi-game gap. Unknown gamemodes/outcomes are Sentry-reported and dropped.
- **`src/helpers/sessionDetail.ts`** — pure derivation (all unit-tested): the session aggregate, per-mode breakdown (including the synthetic "Other" bucket = `overall − core modes`), the FKDR trajectory, milestones, best/fastest game, and the trailing streak. Per-game data is derived on the client from the consecutive `history[]` snapshots — the gamemode whose `gamesPlayed` moved names the game and its stat deltas become the per-game stats.

## Stats-layer groundwork (enables the page)

- **Split the canonical gamemode list** in `src/stats/keys.ts` into `REAL_GAMEMODE_KEYS` (solo/doubles/threes/fours/4v4), with `ALL_GAMEMODE_KEYS = [...REAL_GAMEMODE_KEYS, "overall"]`, so the page's mode list has a single source of truth (`GAMEMODES` reuses it) and adding a mode is a one-line change.
- **`nextCloseMilestone` progression strategy** — tighter targets than the regular page (next 10 stars, next 0.5 for ratios, next "half-decade" for counters) so the page's goals feel a session or two out. Milestones reuse `computeStatProgression`, so targets and ETAs stay in agreement with the regular session page.
- The FKDR trajectory and session aggregate route their ratio stats through `computeStat` rather than re-implementing ratio math.

## Backend contract (matches the flashlight PR)

```
POST /v1/session-at
{ "uuid": "...", "time": "<ISO>" }

-> {
     "session": { "start": PIT, "end": PIT, "consecutive": bool, "ongoing": bool } | null,
     "games":   [ { "start": PIT, "end": PIT, "game": {...} | null }, ... ]
   }
```

`session === null` renders a **"No session yet"** panel — the empty / 404-ish state for a player who hasn't played a game with Prism running.

## URL handling

- Route `/session/$uuid/detail` with a `date` search param (Zod `z.coerce.date()`), following the existing routes' `validateSearch` pattern so we don't have to URL-encode colons/`Z` in the path.
- On the first successful response an effect rewrites `date` to the session's `start.queriedAt` via `navigate({ replace: true })`, pre-seeding the cache for the canonical key so there's no refetch. After that the URL is canonical and safe to share.
- A missing or malformed `date` is coerced to a safe default (degrades to the "No session yet" view) rather than tripping the router's error boundary.
- Share copies `globalThis.location.href` and shows a "Link copied!" Snackbar (MUI `Alert`).

## Adjacent changes

- **Sessions list link** — each non-extrapolated row gets a magnifying-glass link to its detail page. Extrapolated rows have no real session start time on the backend (they'd 404), so they render as plain text.
- **`Layout.tsx`** — the new `/session/$uuid_/detail` route is added to `useShownPlayer` so the shown-player context resolves on the page.

## Choices & assumptions

- **Search param, not path segment**, matching the existing session/history routes.
- **Per-game data is derived on the client** from consecutive snapshots; a missed snapshot collapses two games into one or surfaces a labelled gap — accepted over a much chattier backend response.
- **Lifetime FKDR in the trajectory updates as the session progresses** (session vs all-time after each game), matching the design intent rather than a static baseline. The KPI-row "Δ vs lifetime" instead compares against the pre-session lifetime (lifetime at `session.start`).
- **FKDR trajectory numbering** — points are numbered by running game count: a real game is `G{n}`, a multi-game gap spans its range (`G5-7`), and a no-game window is dropped (it moves no finals) rather than drawn as a flat, mislabelled point.
- **MUI primitives over a new design system**; MUI `Snackbar`/`Alert` instead of adding a toast library.

## Tests

- `pnpm tsc`, `pnpm oxlint:check`, `pnpm oxfmt:check` clean.
- **Unit** — `sessionDetail` (aggregate, modeBreakdown incl. the "Other" bucket, fkdrTrajectory numbering/labels, computeMilestones incl. blocked/off-pace branches, best/fastest game, trailing streak, inferredGameCount), `detailSearch`, and `nextCloseMilestone` (+ strict-monotonic and closer-than-natural properties).
- **UI (MSW)** — the detail page renders the banner/KPIs/section cards, expands a game tile, normalizes the URL to the session start, and shows the no-session empty state; a mocked `POST /v1/session-at` handler was added to the shared handlers.

### Manual verification (staging)

- [ ] Real player with sessions today.
- [ ] "No session yet" empty state for a long-idle player.
- [ ] Share button copies the canonical (post-normalization) URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
