### PR TITLE
router: defer caching to query, prefetch in loaders

### DIFF
--- a/src/createRouter.ts
+++ b/src/createRouter.ts
@@ -7,6 +7,9 @@ export function createAppRouter(queryClient: QueryClient) {
     return createRouter({
         routeTree,
         defaultPreload: "intent",
+        // Defer caching/staleness to TanStack Query so the router doesn't
+        // run a competing cache. See https://tkdodo.eu/blog/tan-stack-router-and-query
+        defaultPreloadStaleTime: 0,
         context: { queryClient },
     });
 }

--- a/src/routes/history.explore.tsx
+++ b/src/routes/history.explore.tsx
@@ -62,32 +62,12 @@ export const Route = createFileRoute("/history/explore")({
     }) => {
         const uuids = normalizeUUIDsSkippingInvalid(rawUUIDs);
         // TODO: Rate limiting
-        void (async () => {
-            try {
-                await Promise.all([
-                    // oxlint-disable-next-line typescript/promise-function-async
-                    ...uuids.map((uuid) =>
-                        queryClient.fetchQuery(
-                            getHistoryQueryOptions({ uuid, start, end, limit }),
-                        ),
-                    ),
-                    // oxlint-disable-next-line typescript/promise-function-async
-                    ...uuids.map((uuid) =>
-                        queryClient.fetchQuery(getUsernameQueryOptions(uuid)),
-                    ),
-                ]);
-            } catch (error: unknown) {
-                captureException(error, {
-                    extra: {
-                        uuids: rawUUIDs,
-                        start,
-                        end,
-                        limit,
-                        message: "Failed to fetch history + username data",
-                    },
-                });
-            }
-        })();
+        for (const uuid of uuids) {
+            void queryClient.prefetchQuery(
+                getHistoryQueryOptions({ uuid, start, end, limit }),
+            );
+            void queryClient.prefetchQuery(getUsernameQueryOptions(uuid));
+        }
     },
     validateSearch: historyExploreSearchSchema,
     // oxlint-disable-next-line eslint/no-use-before-define

--- a/src/routes/session/$uuid.tsx
+++ b/src/routes/session/$uuid.tsx
@@ -99,43 +99,18 @@ export const Route = createFileRoute("/session/$uuid")({
 
         const { day, week, month } = timeIntervals;
         // TODO: Rate limiting
-        void (async () => {
-            try {
-                await Promise.all([
-                    ...[day, week, month].flatMap(({ start, end }) => [
-                        queryClient.fetchQuery(
-                            getHistoryQueryOptions({ uuid, start, end, limit: 2 }),
-                        ),
-                        queryClient.fetchQuery(
-                            getHistoryQueryOptions({
-                                uuid,
-                                start,
-                                end,
-                                limit: 100,
-                            }),
-                        ),
-                    ]),
-                    queryClient.fetchQuery(
-                        getHistoryQueryOptions({
-                            uuid,
-                            ...trackingInterval,
-                            limit: 2,
-                        }),
-                    ),
-                    queryClient.fetchQuery(getUsernameQueryOptions(uuid)),
-                ]);
-            } catch (error: unknown) {
-                captureException(error, {
-                    extra: {
-                        uuid,
-                        trackingInterval,
-                        timeIntervals,
-                        message:
-                            "Failed to fetch history + tracking history + username data",
-                    },
-                });
-            }
-        })();
+        for (const { start, end } of [day, week, month]) {
+            void queryClient.prefetchQuery(
+                getHistoryQueryOptions({ uuid, start, end, limit: 2 }),
+            );
+            void queryClient.prefetchQuery(
+                getHistoryQueryOptions({ uuid, start, end, limit: 100 }),
+            );
+        }
+        void queryClient.prefetchQuery(
+            getHistoryQueryOptions({ uuid, ...trackingInterval, limit: 2 }),
+        );
+        void queryClient.prefetchQuery(getUsernameQueryOptions(uuid));
     },
     validateSearch: sessionSearchSchema,
     // oxlint-disable-next-line eslint/no-use-before-define

--- a/src/routes/wrapped/$uuid.tsx
+++ b/src/routes/wrapped/$uuid.tsx
@@ -68,28 +68,14 @@ export const Route = createFileRoute("/wrapped/$uuid")({
         const uuid = normalizeUUID(rawUUID);
         if (uuid === null) return;
 
-        void (async () => {
-            try {
-                await Promise.all([
-                    queryClient.fetchQuery(
-                        getWrappedQueryOptions({
-                            uuid,
-                            year,
-                            timezone: getDefaultTimeZone(),
-                        }),
-                    ),
-                    queryClient.fetchQuery(getUsernameQueryOptions(uuid)),
-                ]);
-            } catch (error: unknown) {
-                captureException(error, {
-                    extra: {
-                        uuid,
-                        year,
-                        message: "Failed to fetch wrapped + username data",
-                    },
-                });
-            }
-        })();
+        void queryClient.prefetchQuery(
+            getWrappedQueryOptions({
+                uuid,
+                year,
+                timezone: getDefaultTimeZone(),
+            }),
+        );
+        void queryClient.prefetchQuery(getUsernameQueryOptions(uuid));
     },
     validateSearch: wrappedSearchSchema,
     // oxlint-disable-next-line eslint/no-use-before-define


### PR DESCRIPTION
## Summary

Apply two recommendations from [tkdodo's TanStack Router & Query post](https://tkdodo.eu/blog/tan-stack-router-and-query) — let Query own caching/staleness; have loaders prime that cache rather than compete with it.

- Set `defaultPreloadStaleTime: 0` so the router stops running its own 30s preload cache in parallel with Query.
- Switch all three route loaders from `queryClient.fetchQuery` (always refetches, ignores `staleTime`) to `queryClient.prefetchQuery` (respects `staleTime`, doesn't throw). Drops the `void async / try-catch` wrappers; the query functions already `captureException` on failure.

Net effect: per-query `staleTime` finally pays off — username (1h), history outside the active window (Infinity), wrapped — so intent-preloads warm the cache once and subsequent navigations within `staleTime` hit cache instead of re-firing.

No UX change: components keep their per-card `<Skeleton>` fallbacks. `useSuspenseQuery` was considered but skipped — the current `useQuery` pattern lets each card render a tailored skeleton matching its resolved layout, which a route-level Suspense boundary would coarsen.

## Test plan

- [x] `pnpm tsc`
- [x] `pnpm lint:check`
- [x] `pnpm test` (browser tests, headless)
- [ ] Manually: hover a session-card link → DevTools Network shows prefetch; click within the query's `staleTime` → no refetch; React Query Devtools shows entries reused across navigations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)