### PR TITLE
feat: add downloads banner to front page

### DIFF
--- a/src/routes/-index.ui.test.tsx
+++ b/src/routes/-index.ui.test.tsx
@@ -40,6 +40,45 @@ describe("Home page", () => {
             .toBeInTheDocument();
     });
 
+    mswTest("renders downloads banner linking to downloads page", async () => {
+        const { screen } = await renderAppRoute("/");
+
+        const downloadLink = screen.getByRole("link", { name: "Download" });
+        await expect.element(downloadLink).toBeInTheDocument();
+
+        await downloadLink.click();
+
+        await expect.poll(() => globalThis.location.pathname).toBe("/downloads");
+    });
+
+    mswTest("dismissing downloads banner stores it in localStorage", async () => {
+        const { screen } = await renderAppRoute("/");
+
+        const closeButton = screen.getByRole("button", { name: "Close" });
+        await expect.element(closeButton).toBeInTheDocument();
+
+        await closeButton.click();
+
+        await expect
+            .element(screen.getByRole("link", { name: "Download" }))
+            .not.toBeInTheDocument();
+        expect(localStorage.getItem("downloadsBannerDismissed")).toBe("true");
+    });
+
+    mswTest("downloads banner stays hidden when dismissed", async () => {
+        localStorage.setItem("downloadsBannerDismissed", "true");
+
+        const { screen } = await renderAppRoute("/");
+
+        // The rest of the page should render without the banner
+        await expect
+            .element(screen.getByRole("combobox", { name: "Search players" }))
+            .toBeInTheDocument();
+        await expect
+            .element(screen.getByRole("link", { name: "Download" }))
+            .not.toBeInTheDocument();
+    });
+
     mswTest("search brings you to session page", async () => {
         const { screen } = await renderAppRoute("/");
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,15 +1,18 @@
-import { Delete } from "@mui/icons-material";
-import { Button, IconButton, Stack, Typography } from "@mui/material";
+import { Delete, Download } from "@mui/icons-material";
+import { Alert, Button, IconButton, Stack, Typography } from "@mui/material";
 import { captureException } from "@sentry/react";
-import { createFileRoute, createLink } from "@tanstack/react-router";
+import { createFileRoute, createLink, Link } from "@tanstack/react-router";
 
 import { PlayerHead } from "#components/player.tsx";
 import { UserSearch } from "#components/UserSearch.tsx";
 import { useCurrentUser } from "#contexts/CurrentUser/hooks.ts";
 import { usePlayerVisits } from "#contexts/PlayerVisits/hooks.ts";
+import { useLocalStorage } from "#hooks/useLocalStorage.ts";
 import { useUUIDToUsername } from "#queries/username.ts";
 
 const RouterLinkButton = createLink(Button);
+
+const DOWNLOADS_BANNER_DISMISSED_KEY = "downloadsBannerDismissed";
 
 export const Route = createFileRoute("/")({
     // oxlint-disable-next-line eslint/no-use-before-define
@@ -28,6 +31,9 @@ function RouteComponent() {
               ].slice(0, 5)
             : favoriteUUIDs.slice(0, 5);
     const uuidToUsername = useUUIDToUsername(favorites);
+    const [downloadsBannerDismissed, setDownloadsBannerDismissed] = useLocalStorage(
+        DOWNLOADS_BANNER_DISMISSED_KEY,
+    );
 
     return (
         <Stack
@@ -42,6 +48,20 @@ function RouteComponent() {
                 content="The Prism Overlay for Hypixel Bedwars shows the stats of all players in your game and automatically tracks your progress. View your session stats and compare your stats with other players."
             />
             <link rel="canonical" href="https://prismoverlay.com" />
+            {downloadsBannerDismissed === null && (
+                <Alert
+                    severity="info"
+                    icon={<Download fontSize="inherit" />}
+                    onClose={() => {
+                        setDownloadsBannerDismissed("true");
+                    }}
+                >
+                    <Typography variant="body2">
+                        Looking for the overlay? <Link to="/downloads">Download</Link>{" "}
+                        the Prism Overlay to track your stats!
+                    </Typography>
+                </Alert>
+            )}
             <UserSearch
                 onSubmit={(uuid) => {
                     void (async () => {


### PR DESCRIPTION
Visitors landing on the front page from search engines often want to download the overlay. Add a small info banner above the player search linking to the downloads page.

- New `Alert` banner on `/` with a link to `/downloads`
- Close button on the banner that hides it permanently (dismissal stored in `localStorage`)
- UI tests covering the banner link, navigation, dismissal, and persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)