### PR TITLE
chore(dependabot): Use full repo URLs in pre-commit ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,8 @@ updates:
           # oxlint/oxfmt are driven by the npm ecosystem (package.json is the source of
           # truth) and synced into .pre-commit-config.yaml by the check-tool-versions
           # workflow, so don't let pre-commit bump them independently.
-          - dependency-name: "oxc-project/mirrors-oxlint"
-          - dependency-name: "oxc-project/mirrors-oxfmt"
+          - dependency-name: "https://github.com/oxc-project/mirrors-oxlint"
+          - dependency-name: "https://github.com/oxc-project/mirrors-oxfmt"
       groups:
           # Group minor+patch updates together; major & security stay separate
           pre-commit-minor:


### PR DESCRIPTION
For the `pre-commit` ecosystem, dependabot identifies dependencies by the full repository URL as written in `.pre-commit-config.yaml` (e.g. `https://github.com/oxc-project/mirrors-oxlint`), not the `owner/repo` slug. Since `dependency-name` without glob characters is an exact match, the existing ignores for the oxlint/oxfmt mirrors never fired — which is why dependabot still opened #281 and #282 despite the ignore rules added in f77fa27.

Those two PRs won't close automatically when this merges; they need to be closed manually.

Same root cause was fixed in flashlight in Amund211/flashlight#284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)