### PR TITLE
chore: upgrade pnpm to 11.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,5 +83,5 @@
         "vitest": "^4.1.8",
         "vitest-browser-react": "^2.2.0"
     },
-    "packageManager": "pnpm@10.33.0"
+    "packageManager": "pnpm@11.7.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2035,8 +2035,8 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn@8.17.0:
-    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -4972,11 +4972,11 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  acorn-jsx@5.3.2(acorn@8.17.0):
+  acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
-      acorn: 8.17.0
+      acorn: 8.16.0
 
-  acorn@8.17.0: {}
+  acorn@8.16.0: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -5282,8 +5282,8 @@ snapshots:
 
   espree@10.4.0:
     dependencies:
-      acorn: 8.17.0
-      acorn-jsx: 5.3.2(acorn@8.17.0)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 4.2.1
 
   esquery@1.7.0:


### PR DESCRIPTION
## What

Bumps the pinned `packageManager` from `pnpm@10.33.0` → `pnpm@11.7.0`.

The motivation is the **lockfile revalidation** added in pnpm **11.1.3**: before downloading any tarball, `pnpm install` (including `--frozen-lockfile` in CI) now re-checks *existing* lockfile entries against the active supply-chain policies (`minimumReleaseAge`, `blockExoticSubdeps`, `trustPolicy`), not just newly resolved dependencies. Previously these policies only applied at resolution time, so a lockfile committed before the cutoff could slip young packages past the gate.

## Why the bump is a one-line change (no codemod)

The v10→v11 codemod (`pnpx codemod run pnpm-v10-to-v11`) mostly relocates config out of `.npmrc` / `package.json#pnpm` into `pnpm-workspace.yaml`. This repo is already there:

- `.npmrc` is empty
- there is no `package.json#pnpm` field
- `pnpm-workspace.yaml` already uses the v11 shape — `allowBuilds` map, `blockExoticSubdeps: true`, `minimumReleaseAge: 10080` (7 days)

CI prerequisites are also already met: workflows run Node 24 (v11 requires ≥22) and resolve the pnpm version from `packageManager` via `pnpm/action-setup`, so **no workflow changes are needed**.

## Lockfile revalidation caught a real violation (now fixed)

Running `pnpm@11.7.0 install --frozen-lockfile` confirmed the new revalidation fires on the existing lockfile:

```
✗ Lockfile failed supply-chain policy check (656 entries)
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification:
  acorn@8.17.0 was published at 2026-06-11T..., within the minimumReleaseAge cutoff (2026-06-10T...)
```

`acorn@8.17.0` was published inside the 7-day window. Following pnpm's own guidance, `acorn` was re-resolved to the newest **mature** version, `8.16.0` (published 2026-02-19). Its only consumer is `espree@10.4.0`. No exclusion was added and no other dependency was touched — see the second commit (7-line lockfile diff). `pnpm@11.7.0 install --frozen-lockfile` now passes the policy check.

## Commits

1. `chore: upgrade pnpm to 11.7.0` — the `packageManager` bump
2. `chore: downgrade acorn to 8.16.0 to satisfy minimumReleaseAge` — make the lockfile valid under the new revalidation

🤖 Generated with [Claude Code](https://claude.com/claude-code)