### PR TITLE
chore(pnpm): enable trustPolicy no-downgrade for supply-chain safety

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,14 @@ allowBuilds:
 blockExoticSubdeps: true
 
 minimumReleaseAge: 10080
+
+trustPolicy: no-downgrade
+trustPolicyExclude:
+    # Reviewed provenance-adoption artifacts, not takeovers: these pinned versions
+    # predate the maintainers' adoption of npm provenance / trusted publishing, so
+    # no-downgrade flags them as trust downgrades. Pinned to exact versions so a
+    # future bump re-triggers the trust check and a fresh review.
+    - "@reduxjs/toolkit@2.9.0"
+    - "react-redux@9.2.0"
+    - "reselect@5.1.1"
+    - "semver@6.3.1"


### PR DESCRIPTION
## What

Enable pnpm's `trustPolicy: no-downgrade` so installs **fail when a dependency's trust evidence regresses** versus an earlier-published release — a common account-takeover / supply-chain signal. Complements the existing `minimumReleaseAge` cooldown and `blockExoticSubdeps` restriction.

`trustPolicy` is enforced by pnpm 11's **lockfile verification gate**, which re-checks every entry in `pnpm-lock.yaml` on install — including `pnpm install --frozen-lockfile` in CI. (Now that pnpm 11.7.0 is in place, this is live.)

## The 4 `trustPolicyExclude` entries — exactly why they're flagged

Turning the policy on immediately flags **four existing transitive lockfile entries** with `ERR_PNPM_TRUST_DOWNGRADE`. None are direct dependencies.

pnpm derives "trust level" from npm **provenance attestations** + **trusted-publisher** metadata, and critically **compares by publish _date_, not semver**: a version is rejected if *any earlier-published* release of the same package had stronger trust evidence. These packages ship provenance only **intermittently**, so a later pinned version reads as a "downgrade" from an older attested one:

| Package (flagged) | Flagged version | Earlier attested release | Latest (attested?) | Enters via |
|---|---|---|---|---|
| `@reduxjs/toolkit` | `2.9.0` — 2025-09, unattested | `2.1.0` — 2024-01 ✓ | `2.12.0` ✓ (8/116 attested) | `recharts` |
| `react-redux` | `9.2.0` — 2024-12, unattested | `8.1.2` — 2023-07 ✓ | `9.3.0` ✓ (3/142 attested) | `recharts` → RTK |
| `reselect` | `5.1.1` — 2024-06, unattested | `5.1.0` — 2024-01 ✓ | `5.2.0` ✓ (2/54 attested) | `recharts` → RTK |
| `semver` | `6.3.1` — 2023-07, unattested | `7.5.1` — 2023-05 ✓ | `7.8.4` ✓ (6.x never attested) | `@babel/core` (`^6.3.1`) |

## Why we exclude them — and the provenance outlook

**The 3 Redux-stack packages are a benign publishing-pipeline artifact, not a compromise**, confirmed by their maintainer (Mark Erikson). From [reduxjs/reselect#752](https://github.com/reduxjs/reselect/issues/752) (tracker: [redux-toolkit#5095](https://github.com/reduxjs/redux-toolkit/issues/5095)):

> "I've normally published all the Redux-org releases myself, locally. We did set up automated publishing workflows... Those were the ones that had the checkmark. Then I did another publish myself, and that release didn't have the checkmark. I've figured out changes to my own publish process to use the Actions workflow to do the actual release... next Reselect release should have that."

He has since re-shipped **attested** versions — RTK `2.12.0`, [react-redux `9.3.0`](https://github.com/reduxjs/react-redux/releases/tag/v9.3.0), reselect `5.2.0` (all 2026-05-15) — and intends to keep provenance on going forward (caveat: it has regressed before when a manual publish slipped through). **So these 3 excludes are transient** — bumping the dependers to the attested versions should let us drop them (follow-up investigation in progress).

**`semver@6.3.1` is unrelated and effectively permanent.** It's pulled in transitively by `@babel/core` via a `semver: ^6.3.1` range. node-semver only adopted provenance on the **7.x** line; `6.x` is legacy-maintenance and won't be retrofitted, so this exclude stays until Babel (or other requirers) move to `semver@7`.

All excludes are **pinned to exact versions** so any future bump re-triggers the trust check and a fresh review.

## Verification

`CI=true pnpm install --frozen-lockfile` (pnpm 11.7.0): **fails** without the excludes (4 × `ERR_PNPM_TRUST_DOWNGRADE`), **passes** with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
