### PR TITLE
fix(layout): add bottom padding so content has breathing room

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -443,7 +443,26 @@ export const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) =>
                 }}
                 padding={1}
             >
-                {children}
+                {/* Wrap the children in a padded box so the bottom spacer
+                  scrolls with the content — padding on `<main>` itself doesn't,
+                  since it's overflow:visible and ends up flush with the
+                  viewport. `flexGrow` + flex column lets the wrapper fill
+                  `<main>` when content is short (so routes that center on
+                  `height:100%`, e.g. the home page, keep a full-height
+                  containing block) and grow past the viewport when content is
+                  long (so the spacer trails the content). Don't add
+                  `minHeight: 0` here: it clamps the wrapper to the viewport,
+                  burying the spacer mid-content on pages that overflow. */}
+                <Box
+                    sx={{
+                        flexGrow: 1,
+                        display: "flex",
+                        flexDirection: "column",
+                        paddingBottom: 6,
+                    }}
+                >
+                    {children}
+                </Box>
             </Stack>
         </Box>
     );


### PR DESCRIPTION
## Summary

Wrap `<main>`'s children in a box with bottom padding so pages get a real bottom-of-content spacer that scrolls with the content. Padding on `<main>` itself doesn't work — it's `overflow:visible`, so the padding ends up flush with the viewport instead of trailing the content.

The wrapper is a flex column (`flexGrow:1; display:flex; flexDirection:column`) so it fills `<main>` when content is short — keeping a full-height containing block for routes that center on `height:100%` (e.g. the home page) — and grows past the viewport when content is long, so the spacer trails the content.

> **Note:** an earlier revision set `minHeight: 0` on the wrapper (intended to preserve home-page centering). That turned out to be unnecessary — `flexGrow:1` alone provides the full-height containing block — and actively harmful: it clamps the wrapper to the viewport, so on any page that overflows (downloads, history, session, wrapped) the spacer was buried mid-content instead of trailing it. Verified in-browser that removing it fixes the spacer on every scrolling route with no change to home-page centering. Thanks @Copilot for flagging.

Extracted from the session detail page work (#256) as an independent change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
