### PR TITLE
chore(lint): gitignore .mcp.json so oxfmt skips it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ dist-ssr
 
 # Claude config
 /.claude/*
+/.mcp.json


### PR DESCRIPTION
## What

Adds `/.mcp.json` to `.gitignore`.

## Why

The Claude Code harness injects a `.mcp.json` into the project directory during sessions. `oxfmt` walks the project tree, tries to read it, and fails — which breaks `pnpm lint:check` for reasons unrelated to any actual change.

`oxfmt` honors `.gitignore` on its own (verified: placed a deliberately malformed `.mcp.json` on disk and `oxfmt --check` skips it), so a single `.gitignore` line is sufficient — no `.oxfmtrc.json` change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)