### PR TITLE
feat(stats): add BBLR and WLR ratio stats

### DIFF
--- a/src/routes/session/$uuid.tsx
+++ b/src/routes/session/$uuid.tsx
@@ -144,7 +144,7 @@ const renderDuration = (end: Date, start: Date) => {
 };
 
 const isLinearStat = (stat: StatKey) => {
-    return !["fkdr", "kdr", "index"].includes(stat);
+    return !["fkdr", "kdr", "bblr", "wlr", "index"].includes(stat);
 };
 
 const getRelatedStats = (stat: StatKey): StatKey[] => {
@@ -154,6 +154,12 @@ const getRelatedStats = (stat: StatKey): StatKey[] => {
         }
         case "kdr": {
             return ["kills", "deaths"];
+        }
+        case "bblr": {
+            return ["bedsBroken", "bedsLost"];
+        }
+        case "wlr": {
+            return ["wins", "losses"];
         }
         case "index": {
             return ["finalKills", "finalDeaths", "stars"];
@@ -773,7 +779,7 @@ const SessionStatCard: React.FC<SessionStatCardProps> = ({
 
     const badStats: StatKey[] = ["deaths", "finalDeaths", "bedsLost", "losses"];
     // Intentionally not including "index" as the number is usually so large that we don't want decmials. TODO: Could be fixed by better conditional decimal rendering for large numbers.
-    const floatStats: StatKey[] = ["fkdr", "kdr", "stars"];
+    const floatStats: StatKey[] = ["fkdr", "kdr", "bblr", "wlr", "stars"];
 
     const shortPrecision = floatStats.includes(stat) ? 2 : 0;
     const shortFormat: Intl.NumberFormatOptions = {
@@ -926,7 +932,9 @@ const ProgressionValueAndMilestone: React.FC<ProgressionValueAndMilestoneProps> 
             );
         }
         case "fkdr":
-        case "kdr": {
+        case "kdr":
+        case "bblr":
+        case "wlr": {
             return renderValues(
                 progression.endValue,
                 progression.nextMilestoneValue,
@@ -1001,6 +1009,20 @@ const ProgressionCaption: React.FC<ProgressionCaptionProps> = ({ progression }) 
             return (
                 <Typography variant="caption">
                     {`${progression.progressPerDay.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}/day (${progression.sessionQuotient.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} long-time ${getShortStatLabel("kdr")}, ${progression.dividendPerDay.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${getShortStatLabel("kills")}/day, ${progression.divisorPerDay.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${getShortStatLabel("deaths")}/day)`}
+                </Typography>
+            );
+        }
+        case "bblr": {
+            return (
+                <Typography variant="caption">
+                    {`${progression.progressPerDay.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}/day (${progression.sessionQuotient.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} long-time ${getShortStatLabel("bblr")}, ${progression.dividendPerDay.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${getShortStatLabel("bedsBroken")}/day, ${progression.divisorPerDay.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${getShortStatLabel("bedsLost")}/day)`}
+                </Typography>
+            );
+        }
+        case "wlr": {
+            return (
+                <Typography variant="caption">
+                    {`${progression.progressPerDay.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}/day (${progression.sessionQuotient.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} long-time ${getShortStatLabel("wlr")}, ${progression.dividendPerDay.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${getShortStatLabel("wins")}/day, ${progression.divisorPerDay.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${getShortStatLabel("losses")}/day)`}
                 </Typography>
             );
         }
@@ -1287,7 +1309,7 @@ function RouteComponent() {
 
     // Stats where we want to show the session value AND the all-time value
     // These are stats where the session and all-time values are usually close
-    const statsWhereSessionIsCloseToAllTime: StatKey[] = ["fkdr", "kdr"];
+    const statsWhereSessionIsCloseToAllTime: StatKey[] = ["fkdr", "kdr", "bblr", "wlr"];
 
     return (
         <Stack spacing={1}>

--- a/src/stats/index.ts
+++ b/src/stats/index.ts
@@ -45,6 +45,20 @@ export function getStat(
             }
             return kills / deaths;
         }
+        case "bblr": {
+            const { bedsBroken, bedsLost } = selectedGamemode;
+            if (bedsLost === 0) {
+                return bedsBroken;
+            }
+            return bedsBroken / bedsLost;
+        }
+        case "wlr": {
+            const { wins, losses } = selectedGamemode;
+            if (losses === 0) {
+                return wins;
+            }
+            return wins / losses;
+        }
         case "index": {
             const fkdr = getStat(playerData, gamemode, "fkdr");
             const stars = getStat(playerData, gamemode, "stars");
@@ -133,6 +147,42 @@ export function computeStat(
                 return kills;
             }
             return kills / deaths;
+        }
+        case "bblr": {
+            const bedsBroken = computeStat(
+                playerData,
+                gamemode,
+                "bedsBroken",
+                variant,
+                history,
+            );
+            const bedsLost = computeStat(
+                playerData,
+                gamemode,
+                "bedsLost",
+                variant,
+                history,
+            );
+
+            if (bedsLost === 0) {
+                return bedsBroken;
+            }
+            return bedsBroken / bedsLost;
+        }
+        case "wlr": {
+            const wins = computeStat(playerData, gamemode, "wins", variant, history);
+            const losses = computeStat(
+                playerData,
+                gamemode,
+                "losses",
+                variant,
+                history,
+            );
+
+            if (losses === 0) {
+                return wins;
+            }
+            return wins / losses;
         }
         case "index": {
             const fkdr = computeStat(playerData, gamemode, "fkdr", variant, history);

--- a/src/stats/keys.ts
+++ b/src/stats/keys.ts
@@ -14,10 +14,10 @@ export const GAMEMODE_STAT_KEYS = [
     "deaths",
     "fkdr",
     "kdr",
-    "index",
-    /*
     "bblr",
     "wlr",
+    "index",
+    /*
     "clutchRate",
     */
 ] as const;

--- a/src/stats/labels.ts
+++ b/src/stats/labels.ts
@@ -44,6 +44,12 @@ export const getFullStatLabel = (stat: StatKey, capitalize = false): string => {
         case "fkdr": {
             return capitalize ? "Final kill/death ratio" : "final kill/death ratio";
         }
+        case "bblr": {
+            return capitalize ? "Beds broken/lost ratio" : "beds broken/lost ratio";
+        }
+        case "wlr": {
+            return capitalize ? "Win/loss ratio" : "win/loss ratio";
+        }
         case "index": {
             return capitalize ? "Index (FKDR^2 * Stars)" : "index (FKDR^2 * stars)";
         }
@@ -93,6 +99,12 @@ export const getShortStatLabel = (stat: StatKey, capitalize = false): string => 
         }
         case "fkdr": {
             return capitalize ? "FKDR" : "FKDR";
+        }
+        case "bblr": {
+            return capitalize ? "BBLR" : "BBLR";
+        }
+        case "wlr": {
+            return capitalize ? "WLR" : "WLR";
         }
         case "index": {
             return capitalize ? "Index" : "index";

--- a/src/stats/progression.ts
+++ b/src/stats/progression.ts
@@ -141,7 +141,9 @@ export const nextNaturalMilestone: MilestoneStrategy = (
             return (Math.floor(value / 100) + 1) * 100;
         }
         case "fkdr":
-        case "kdr": {
+        case "kdr":
+        case "bblr":
+        case "wlr": {
             return trendingUpward ? Math.floor(value) + 1 : Math.ceil(value) - 1;
         }
         default: {
@@ -162,7 +164,7 @@ interface BaseStatProgression {
 }
 
 type QuotientProgression = BaseStatProgression & {
-    stat: "fkdr" | "kdr";
+    stat: "fkdr" | "kdr" | "bblr" | "wlr";
     sessionQuotient: number;
     dividendPerDay: number;
     divisorPerDay: number;
@@ -177,7 +179,9 @@ type IndexProgression = BaseStatProgression & {
 };
 
 export type StatProgression =
-    | (BaseStatProgression & { stat: Exclude<StatKey, "fkdr" | "kdr" | "index"> })
+    | (BaseStatProgression & {
+          stat: Exclude<StatKey, "fkdr" | "kdr" | "bblr" | "wlr" | "index">;
+      })
     | QuotientProgression
     | IndexProgression;
 
@@ -408,6 +412,28 @@ export const computeStatProgression = (
                 stat,
                 "kills",
                 "deaths",
+                gamemode,
+                milestoneStrategy,
+            );
+        }
+        case "bblr": {
+            return computeQuotientProgression(
+                trackingHistory,
+                trackingEnd,
+                stat,
+                "bedsBroken",
+                "bedsLost",
+                gamemode,
+                milestoneStrategy,
+            );
+        }
+        case "wlr": {
+            return computeQuotientProgression(
+                trackingHistory,
+                trackingEnd,
+                stat,
+                "wins",
+                "losses",
                 gamemode,
                 milestoneStrategy,
             );

--- a/src/stats/progression.unit.test.ts
+++ b/src/stats/progression.unit.test.ts
@@ -41,12 +41,22 @@ class StatsBuilder {
     public withStat(
         stat: Exclude<
             StatKey,
-            "winstreak" | "fkdr" | "kdr" | "index" | "stars" | "experience"
+            | "winstreak"
+            | "fkdr"
+            | "kdr"
+            | "bblr"
+            | "wlr"
+            | "index"
+            | "stars"
+            | "experience"
         >,
         value: number,
     ): this;
     public withStat(
-        stat: Exclude<StatKey, "fkdr" | "kdr" | "index" | "stars" | "experience">,
+        stat: Exclude<
+            StatKey,
+            "fkdr" | "kdr" | "bblr" | "wlr" | "index" | "stars" | "experience"
+        >,
         value: number | null,
     ): this {
         switch (stat) {
@@ -472,7 +482,7 @@ describe("computeStatProgression - linear gamemode stats", () => {
 });
 
 describe("computeStatProgression - quotient stats", () => {
-    const quotientStats = ["fkdr", "kdr"] as const;
+    const quotientStats = ["fkdr", "kdr", "bblr", "wlr"] as const;
     const gamemodes = ALL_GAMEMODE_KEYS;
 
     type QuotientStatKey = (typeof quotientStats)[number];
@@ -485,6 +495,12 @@ describe("computeStatProgression - quotient stats", () => {
             case "kdr": {
                 return "kills";
             }
+            case "bblr": {
+                return "bedsBroken";
+            }
+            case "wlr": {
+                return "wins";
+            }
         }
     };
 
@@ -495,6 +511,12 @@ describe("computeStatProgression - quotient stats", () => {
             }
             case "kdr": {
                 return "deaths";
+            }
+            case "bblr": {
+                return "bedsLost";
+            }
+            case "wlr": {
+                return "losses";
             }
         }
     };


### PR DESCRIPTION
## Summary

Adds two new ratio stats, mirroring the existing FKDR/KDR quotient handling end-to-end:

- **BBLR** — beds broken / lost ratio (`bedsBroken / bedsLost`)
- **WLR** — win / loss ratio (`wins / losses`)

Both reuse the existing quotient-progression machinery, so they get milestone projection, session/all-time values, related-stat breakdowns, and labels for free. No data-model changes were needed — `wins`, `losses`, `bedsBroken`, and `bedsLost` already exist in `StatsPIT`.

## Changes

- `src/stats/keys.ts` — register `bblr`, `wlr`
- `src/stats/index.ts` — `getStat` + `computeStat` cases
- `src/stats/labels.ts` — full + short labels
- `src/stats/progression.ts` — milestone strategy, `QuotientProgression` union, progression cases
- `src/routes/session/$uuid.tsx` — linear/related-stat handling, float formatting, progression value + caption rendering
- `src/stats/progression.unit.test.ts` — extend the parametric quotient-stats suite to cover bblr/wlr

## Verification

`tsc`, `oxlint`, `oxfmt`, 754 unit tests, and 201 UI tests all pass (also enforced by the pre-commit hook).

## Left for follow-up

- **winrate** (`wins / gamesPlayed`, shown as a percentage) — intentionally not in this PR. Unlike the pure ratios it's bounded 0–1 and wants percentage-aware formatting plus percentage-step milestones (e.g. next 5%) rather than the whole-number ratio milestones, so it warrants its own change.
- **clutchRate** — blocked upstream: there is no clutch data anywhere in the pipeline (`StatsPIT`, the flashlight backend, or the API response), so it can't be computed without a data-model change first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
