### PR TITLE
feat(stats): add winrate stat rendered as a percentage

### DIFF
--- a/src/charts/history/chart.tsx
+++ b/src/charts/history/chart.tsx
@@ -19,6 +19,7 @@ import { useSynchronizeCharts } from "#contexts/ChartSynchronizer/hooks.ts";
 import { useAssume } from "#hooks/useAssumption.ts";
 import { getHistoryQueryOptions } from "#queries/history.ts";
 import { useUUIDToUsername } from "#queries/username.ts";
+import { formatStatValue } from "#stats/format.ts";
 import type { GamemodeKey, StatKey, VariantKey } from "#stats/keys.ts";
 import { getFullStatLabel, getGamemodeLabel, getVariantLabel } from "#stats/labels.ts";
 
@@ -275,6 +276,16 @@ export const HistoryChart: React.FC<HistoryChartProps> = ({
         };
     };
 
+    // oxlint-disable-next-line eslint/no-use-before-define
+    const { lines, statByDataKey } = renderLines({
+        uuids,
+        gamemodes,
+        stats,
+        variants,
+        uuidToUsername,
+        lineStyle,
+    });
+
     return (
         <LineChart
             data={mutableChartData}
@@ -306,17 +317,7 @@ export const HistoryChart: React.FC<HistoryChartProps> = ({
                 tick={{ fill: theme.palette.text.secondary, fontSize: 12 }}
             />
             <CartesianGrid stroke={theme.palette.divider} strokeDasharray="2 4" />
-            {
-                // oxlint-disable-next-line eslint/no-use-before-define
-                renderLines({
-                    uuids,
-                    gamemodes,
-                    stats,
-                    variants,
-                    uuidToUsername,
-                    lineStyle,
-                })
-            }
+            {lines}
             {/* Future marker */}
             <ReferenceArea
                 x1={currentDate.getTime()}
@@ -337,6 +338,12 @@ export const HistoryChart: React.FC<HistoryChartProps> = ({
                         timeTypeof: typeof label,
                     }));
                     return label;
+                }}
+                formatter={(value, _name, item) => {
+                    const stat = statByDataKey.get(String(item.dataKey));
+                    return typeof value === "number" && stat !== undefined
+                        ? formatStatValue(stat, value, { precision: "detailed" })
+                        : value;
                 }}
                 contentStyle={{
                     backgroundColor: theme.palette.background.paper,
@@ -497,8 +504,7 @@ export const SimpleHistoryChart: React.FC<SimpleHistoryChartProps> = ({
                         return null;
                     }
 
-                    // TODO: Better number formatting
-                    return value.toLocaleString();
+                    return formatStatValue(stat, value, { precision: "detailed" });
                 }}
                 contentStyle={{
                     backgroundColor: theme.palette.background.paper,
@@ -527,9 +533,16 @@ const renderLines = ({
     variants,
     uuidToUsername,
     lineStyle,
-}: LinesProps): React.ReactNode[] => {
+}: LinesProps): {
+    lines: React.ReactNode[];
+    statByDataKey: Map<string, StatKey>;
+} => {
     let index = 0;
-    return uuids.flatMap((uuid) => {
+    // Authoritative dataKey → stat lookup, built where each line is created so
+    // the tooltip formatter never has to reverse-parse the dataKey string
+    // (uuids and the "4v4" gamemode make splitting fragile).
+    const statByDataKey = new Map<string, StatKey>();
+    const lines = uuids.flatMap((uuid) => {
         return stats.flatMap((stat) => {
             return variants.flatMap((variant) => {
                 if (stat === "stars" || stat === "experience") {
@@ -540,6 +553,7 @@ const renderLines = ({
                         stat,
                         variant,
                     });
+                    statByDataKey.set(dataKey, stat);
                     return (
                         <Line
                             key={dataKey}
@@ -578,6 +592,7 @@ const renderLines = ({
                         stat,
                         variant,
                     });
+                    statByDataKey.set(dataKey, stat);
                     return (
                         <Line
                             key={dataKey}
@@ -611,4 +626,5 @@ const renderLines = ({
             });
         });
     });
+    return { lines, statByDataKey };
 };

--- a/src/routes/session/$uuid.tsx
+++ b/src/routes/session/$uuid.tsx
@@ -148,7 +148,7 @@ const renderDuration = (end: Date, start: Date) => {
 const BAD_STATS: readonly StatKey[] = ["deaths", "finalDeaths", "bedsLost", "losses"];
 
 const isLinearStat = (stat: StatKey) => {
-    return !["fkdr", "kdr", "bblr", "wlr", "index"].includes(stat);
+    return !["fkdr", "kdr", "bblr", "wlr", "index", "winrate"].includes(stat);
 };
 
 const getRelatedStats = (stat: StatKey): StatKey[] => {
@@ -164,6 +164,9 @@ const getRelatedStats = (stat: StatKey): StatKey[] => {
         }
         case "wlr": {
             return ["wins", "losses"];
+        }
+        case "winrate": {
+            return ["wins", "gamesPlayed"];
         }
         case "index": {
             return ["finalKills", "finalDeaths", "stars"];
@@ -956,6 +959,16 @@ const ProgressionCaption: React.FC<ProgressionCaptionProps> = ({ progression }) 
                 </Typography>
             );
         }
+        case "winrate": {
+            // progressPerDay and sessionQuotient are fractions -> render as %.
+            // dividendPerDay (wins/day) and divisorPerDay (games/day) are
+            // fractional rates, not winrates -> keep the plain 2dp number format.
+            return (
+                <Typography variant="caption">
+                    {`${formatStatValue("winrate", progression.progressPerDay)}/day (${formatStatValue("winrate", progression.sessionQuotient)} long-time ${getShortStatLabel("winrate")}, ${progression.dividendPerDay.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${getShortStatLabel("wins")}/day, ${progression.divisorPerDay.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${getShortStatLabel("gamesPlayed")}/day)`}
+                </Typography>
+            );
+        }
         case "index": {
             return (
                 <Typography variant="caption">
@@ -1239,7 +1252,13 @@ function RouteComponent() {
 
     // Stats where we want to show the session value AND the all-time value
     // These are stats where the session and all-time values are usually close
-    const statsWhereSessionIsCloseToAllTime: StatKey[] = ["fkdr", "kdr", "bblr", "wlr"];
+    const statsWhereSessionIsCloseToAllTime: StatKey[] = [
+        "fkdr",
+        "kdr",
+        "bblr",
+        "wlr",
+        "winrate",
+    ];
 
     return (
         <Stack spacing={1}>

--- a/src/routes/session/$uuid.tsx
+++ b/src/routes/session/$uuid.tsx
@@ -57,6 +57,7 @@ import { getSessionsQueryOptions } from "#queries/sessions.ts";
 import type { Sessions } from "#queries/sessions.ts";
 import { getUsernameQueryOptions, useUUIDToUsername } from "#queries/username.ts";
 import { sessionSearchSchema } from "#schemas/sessionSearch.ts";
+import { formatStatValue } from "#stats/format.ts";
 import { computeStat } from "#stats/index.ts";
 import { ALL_GAMEMODE_KEYS, ALL_STAT_KEYS } from "#stats/keys.ts";
 import type { GamemodeKey, StatKey } from "#stats/keys.ts";
@@ -142,6 +143,9 @@ const renderDuration = (end: Date, start: Date) => {
 
     return hours ? `${hours.toLocaleString()}h ${paddedMinutes}m` : `${paddedMinutes}m`;
 };
+
+// Stats where a positive trend is "bad" (i.e. rendered in error colours).
+const BAD_STATS: readonly StatKey[] = ["deaths", "finalDeaths", "bedsLost", "losses"];
 
 const isLinearStat = (stat: StatKey) => {
     return !["fkdr", "kdr", "bblr", "wlr", "index"].includes(stat);
@@ -473,9 +477,9 @@ const Sessions: React.FC<SessionsProps> = ({
                                                 return formattedNumber;
                                             }
 
-                                            return value.toLocaleString(
-                                                /*TODO: format based on stat type*/
-                                            );
+                                            return formatStatValue(statKey, value, {
+                                                precision: "detailed",
+                                            });
                                         };
 
                                         const textColor: TypographyOwnProps["color"] =
@@ -777,26 +781,10 @@ const SessionStatCard: React.FC<SessionStatCardProps> = ({
         trendDirection = "down";
     }
 
-    const badStats: StatKey[] = ["deaths", "finalDeaths", "bedsLost", "losses"];
-    // Intentionally not including "index" as the number is usually so large that we don't want decmials. TODO: Could be fixed by better conditional decimal rendering for large numbers.
-    const floatStats: StatKey[] = ["fkdr", "kdr", "bblr", "wlr", "stars"];
-
-    const shortPrecision = floatStats.includes(stat) ? 2 : 0;
-    const shortFormat: Intl.NumberFormatOptions = {
-        minimumFractionDigits: shortPrecision,
-        maximumFractionDigits: shortPrecision,
-    };
-
-    const longPrecision = floatStats.includes(stat) ? 3 : 0;
-    const longFormat: Intl.NumberFormatOptions = {
-        minimumFractionDigits: longPrecision,
-        maximumFractionDigits: longPrecision,
-    };
-
     let trendColor: SvgIconOwnProps["color"];
     if (trendDirection === "flat") {
         trendColor = undefined;
-    } else if ((trendDirection === "up") === badStats.includes(stat)) {
+    } else if ((trendDirection === "up") === BAD_STATS.includes(stat)) {
         trendColor = "error";
     } else {
         trendColor = "success";
@@ -815,22 +803,21 @@ const SessionStatCard: React.FC<SessionStatCardProps> = ({
                             justifyContent="space-between"
                         >
                             <Typography variant="body1">
-                                {sessionValue.toLocaleString(undefined, {
-                                    ...longFormat,
+                                {formatStatValue(stat, sessionValue, {
+                                    precision: "detailed",
                                 })}
                             </Typography>
                             <Tooltip
-                                title={`${startValue.toLocaleString(undefined, {
-                                    ...longFormat,
-                                })} → ${endValue.toLocaleString(undefined, {
-                                    ...longFormat,
+                                title={`${formatStatValue(stat, startValue, {
+                                    precision: "detailed",
+                                })} → ${formatStatValue(stat, endValue, {
+                                    precision: "detailed",
                                 })}`}
                             >
                                 <Stack direction="row" gap={0.5} alignItems="center">
                                     <Typography variant="caption" color={trendColor}>
-                                        {diff.toLocaleString(undefined, {
+                                        {formatStatValue(stat, diff, {
                                             signDisplay: "always",
-                                            ...shortFormat,
                                         })}
                                     </Typography>
                                     {diff > 0 && (
@@ -915,73 +902,16 @@ const ProgressionValueAndMilestone: React.FC<ProgressionValueAndMilestoneProps> 
             </Stack>
         );
     };
-    switch (progression.stat) {
-        case "stars": {
-            // TODO: Format based on prestige colors
-            return renderValues(
-                progression.endValue,
-                progression.nextMilestoneValue,
-                (value) => (
-                    <Typography variant="body1">
-                        {value.toLocaleString(undefined, {
-                            maximumFractionDigits: 2,
-                        })}
-                    </Typography>
-                ),
-                false,
-            );
-        }
-        case "fkdr":
-        case "kdr":
-        case "bblr":
-        case "wlr": {
-            return renderValues(
-                progression.endValue,
-                progression.nextMilestoneValue,
-                (value) => (
-                    <Typography variant="body1">
-                        {value.toLocaleString(undefined, {
-                            maximumFractionDigits: 2,
-                        })}
-                    </Typography>
-                ),
-                false,
-            );
-        }
-        case "index":
-        case "experience":
-        case "winstreak":
-        case "gamesPlayed":
-        case "wins":
-        case "bedsBroken":
-        case "finalKills":
-        case "kills": {
-            return renderValues(
-                progression.endValue,
-                progression.nextMilestoneValue,
-                (value) => (
-                    <Typography variant="body1">{value.toLocaleString()}</Typography>
-                ),
-                false,
-            );
-        }
-        case "losses":
-        case "bedsLost":
-        case "finalDeaths":
-        case "deaths": {
-            return renderValues(
-                progression.endValue,
-                progression.nextMilestoneValue,
-                (value) => (
-                    <Typography variant="body1">{value.toLocaleString()}</Typography>
-                ),
-                true,
-            );
-        }
-        default: {
-            progression satisfies never;
-        }
-    }
+    return renderValues(
+        progression.endValue,
+        progression.nextMilestoneValue,
+        (value) => (
+            <Typography variant="body1">
+                {formatStatValue(progression.stat, value)}
+            </Typography>
+        ),
+        BAD_STATS.includes(progression.stat),
+    );
 };
 
 interface ProgressionCaptionProps {

--- a/src/stats/format.ts
+++ b/src/stats/format.ts
@@ -1,6 +1,6 @@
 import type { StatKey } from "./keys.ts";
 
-export type StatFormatKind = "integer" | "decimal";
+export type StatFormatKind = "integer" | "decimal" | "percentage";
 
 // Record<StatKey, …> is exhaustive: a new stat won't compile until its format
 // kind is declared here. (Commit 3 adds "percentage" and the `winrate` entry.)
@@ -21,6 +21,7 @@ export const STAT_FORMAT_KIND: Record<StatKey, StatFormatKind> = {
     kdr: "decimal",
     bblr: "decimal",
     wlr: "decimal",
+    winrate: "percentage",
     index: "integer",
 };
 
@@ -51,6 +52,18 @@ export const formatStatValue = (
         case "integer": {
             return value.toLocaleString(undefined, {
                 maximumFractionDigits: 0,
+                signDisplay,
+            });
+        }
+        case "percentage": {
+            // `style: "percent"` scales by 100 and appends a locale-aware percent
+            // sign/spacing, so pass the raw fraction (not `value * 100`).
+            // min = max (like the decimal case) for a fixed number of decimals.
+            const digits = precision === "detailed" ? 2 : 1;
+            return value.toLocaleString(undefined, {
+                style: "percent",
+                minimumFractionDigits: digits,
+                maximumFractionDigits: digits,
                 signDisplay,
             });
         }

--- a/src/stats/format.ts
+++ b/src/stats/format.ts
@@ -1,0 +1,58 @@
+import type { StatKey } from "./keys.ts";
+
+export type StatFormatKind = "integer" | "decimal";
+
+// Record<StatKey, …> is exhaustive: a new stat won't compile until its format
+// kind is declared here. (Commit 3 adds "percentage" and the `winrate` entry.)
+export const STAT_FORMAT_KIND: Record<StatKey, StatFormatKind> = {
+    experience: "integer",
+    stars: "decimal",
+    winstreak: "integer",
+    gamesPlayed: "integer",
+    wins: "integer",
+    losses: "integer",
+    bedsBroken: "integer",
+    bedsLost: "integer",
+    finalKills: "integer",
+    finalDeaths: "integer",
+    kills: "integer",
+    deaths: "integer",
+    fkdr: "decimal",
+    kdr: "decimal",
+    bblr: "decimal",
+    wlr: "decimal",
+    index: "integer",
+};
+
+export const getStatFormatKind = (stat: StatKey): StatFormatKind =>
+    STAT_FORMAT_KIND[stat];
+
+interface FormatStatValueOptions {
+    // "compact" → cards / diffs / short contexts (fewer decimals);
+    // "detailed" → values / tooltips / hover detail (more decimals).
+    readonly precision?: "compact" | "detailed";
+    readonly signDisplay?: Intl.NumberFormatOptions["signDisplay"];
+}
+
+export const formatStatValue = (
+    stat: StatKey,
+    value: number,
+    { precision = "compact", signDisplay }: FormatStatValueOptions = {},
+): string => {
+    switch (getStatFormatKind(stat)) {
+        case "decimal": {
+            const digits = precision === "detailed" ? 3 : 2;
+            return value.toLocaleString(undefined, {
+                minimumFractionDigits: digits,
+                maximumFractionDigits: digits,
+                signDisplay,
+            });
+        }
+        case "integer": {
+            return value.toLocaleString(undefined, {
+                maximumFractionDigits: 0,
+                signDisplay,
+            });
+        }
+    }
+};

--- a/src/stats/index.ts
+++ b/src/stats/index.ts
@@ -59,6 +59,11 @@ export function getStat(
             }
             return wins / losses;
         }
+        case "winrate": {
+            const { wins, gamesPlayed } = selectedGamemode;
+            // A win always increments gamesPlayed, so gamesPlayed === 0 ⇒ wins === 0.
+            return gamesPlayed === 0 ? 0 : wins / gamesPlayed;
+        }
         case "index": {
             const fkdr = getStat(playerData, gamemode, "fkdr");
             const stars = getStat(playerData, gamemode, "stars");
@@ -183,6 +188,18 @@ export function computeStat(
                 return wins;
             }
             return wins / losses;
+        }
+        case "winrate": {
+            const wins = computeStat(playerData, gamemode, "wins", variant, history);
+            const gamesPlayed = computeStat(
+                playerData,
+                gamemode,
+                "gamesPlayed",
+                variant,
+                history,
+            );
+            // A win always increments gamesPlayed, so gamesPlayed === 0 ⇒ wins === 0.
+            return gamesPlayed === 0 ? 0 : wins / gamesPlayed;
         }
         case "index": {
             const fkdr = computeStat(playerData, gamemode, "fkdr", variant, history);

--- a/src/stats/keys.ts
+++ b/src/stats/keys.ts
@@ -16,6 +16,7 @@ export const GAMEMODE_STAT_KEYS = [
     "kdr",
     "bblr",
     "wlr",
+    "winrate",
     "index",
     /*
     "clutchRate",

--- a/src/stats/labels.ts
+++ b/src/stats/labels.ts
@@ -50,6 +50,9 @@ export const getFullStatLabel = (stat: StatKey, capitalize = false): string => {
         case "wlr": {
             return capitalize ? "Win/loss ratio" : "win/loss ratio";
         }
+        case "winrate": {
+            return capitalize ? "Win rate" : "win rate";
+        }
         case "index": {
             return capitalize ? "Index (FKDR^2 * Stars)" : "index (FKDR^2 * stars)";
         }
@@ -105,6 +108,9 @@ export const getShortStatLabel = (stat: StatKey, capitalize = false): string => 
         }
         case "wlr": {
             return capitalize ? "WLR" : "WLR";
+        }
+        case "winrate": {
+            return capitalize ? "WR" : "WR";
         }
         case "index": {
             return capitalize ? "Index" : "index";

--- a/src/stats/progression.ts
+++ b/src/stats/progression.ts
@@ -115,9 +115,16 @@ const nextRoundNumberMilestone = (value: number, trendingUpward: boolean): numbe
  *
  * CONTRACT: the returned value MUST be strictly greater than `value` when
  * `trendingUpward`, and strictly less than `value` when `!trendingUpward`. The
- * time-to-reach solvers rely on this to keep `daysUntilMilestone` non-negative
- * and correctly signed; a value on the wrong side produces a negative or
- * nonsensical projection, and the renderer has no defense against it.
+ * time-to-reach solvers rely on strict inequality (`>` / `<`, never `>=` / `<=`)
+ * to keep `daysUntilMilestone` non-negative and correctly signed; a value on the
+ * wrong side produces a negative or nonsensical projection, and the renderer has
+ * no defense against it.
+ *
+ * EXCEPTION: a bounded stat clamped at the edge of its range (winrate at 0% / 100%)
+ * has no further step, so this returns `value` itself. Callers MUST detect
+ * `milestone === value` and treat it as "already reached" BEFORE handing it to the
+ * solver, which still assumes strict inequality (see computeQuotientProgression).
+ * TODO: model "no further milestone" as a first-class state instead of returning `value`.
  */
 export type MilestoneStrategy = (
     value: number,
@@ -146,6 +153,18 @@ export const nextNaturalMilestone: MilestoneStrategy = (
         case "wlr": {
             return trendingUpward ? Math.floor(value) + 1 : Math.ceil(value) - 1;
         }
+        case "winrate": {
+            // Winrate is a fraction in [0, 1]; step by 5% in the trend direction,
+            // clamped into [0, 1] so a near-perfect record can't project past 100%
+            // (or below 0%). At the clamp boundary this returns `value` itself,
+            // which the callers must treat as "already reached" (see the CONTRACT
+            // note above and computeQuotientProgression).
+            const step = 0.05;
+            const next = trendingUpward
+                ? (Math.floor(value / step + 1e-9) + 1) * step
+                : (Math.ceil(value / step - 1e-9) - 1) * step;
+            return Math.min(1, Math.max(0, next));
+        }
         default: {
             return nextRoundNumberMilestone(value, trendingUpward);
         }
@@ -164,7 +183,7 @@ interface BaseStatProgression {
 }
 
 type QuotientProgression = BaseStatProgression & {
-    stat: "fkdr" | "kdr" | "bblr" | "wlr";
+    stat: "fkdr" | "kdr" | "bblr" | "wlr" | "winrate";
     sessionQuotient: number;
     dividendPerDay: number;
     divisorPerDay: number;
@@ -180,7 +199,7 @@ type IndexProgression = BaseStatProgression & {
 
 export type StatProgression =
     | (BaseStatProgression & {
-          stat: Exclude<StatKey, "fkdr" | "kdr" | "bblr" | "wlr" | "index">;
+          stat: Exclude<StatKey, "fkdr" | "kdr" | "bblr" | "wlr" | "winrate" | "index">;
       })
     | QuotientProgression
     | IndexProgression;
@@ -250,6 +269,26 @@ const computeQuotientProgression = (
         sessionQuotient >= endQuotient || noSessionProgress || infiniteSessionQuotient;
 
     const nextMilestoneValue = milestoneStrategy(endQuotient, trendingUpward, stat);
+
+    if (nextMilestoneValue === endQuotient) {
+        // The milestone equals the current value: a bounded stat (winrate) is
+        // clamped at the edge of its range and has no further step. Report it as
+        // reached now (0 days) instead of letting the solver below divide 0/0 into
+        // NaN. The strict-monotonic solver never sees this degenerate case.
+        // TODO: represent "no further milestone" as a first-class progression state.
+        return {
+            stat,
+            trackingDataTimeInterval: { start: startDate, end: endDate },
+            endValue: endQuotient,
+            nextMilestoneValue,
+            daysUntilMilestone: 0,
+            progressPerDay: 0,
+            sessionQuotient,
+            dividendPerDay,
+            divisorPerDay,
+            trendingUpward,
+        };
+    }
 
     if (
         // Will make no progress since the quotients are equal (as long as the session quotient is not infinite)
@@ -434,6 +473,17 @@ export const computeStatProgression = (
                 stat,
                 "wins",
                 "losses",
+                gamemode,
+                milestoneStrategy,
+            );
+        }
+        case "winrate": {
+            return computeQuotientProgression(
+                trackingHistory,
+                trackingEnd,
+                stat,
+                "wins",
+                "gamesPlayed",
                 gamemode,
                 milestoneStrategy,
             );

--- a/src/stats/progression.unit.test.ts
+++ b/src/stats/progression.unit.test.ts
@@ -46,6 +46,7 @@ class StatsBuilder {
             | "kdr"
             | "bblr"
             | "wlr"
+            | "winrate"
             | "index"
             | "stars"
             | "experience"
@@ -55,7 +56,14 @@ class StatsBuilder {
     public withStat(
         stat: Exclude<
             StatKey,
-            "fkdr" | "kdr" | "bblr" | "wlr" | "index" | "stars" | "experience"
+            | "fkdr"
+            | "kdr"
+            | "bblr"
+            | "wlr"
+            | "winrate"
+            | "index"
+            | "stars"
+            | "experience"
         >,
         value: number | null,
     ): this {
@@ -973,6 +981,190 @@ describe("computeStatProgression - quotient stats", () => {
                     });
                 });
             }
+        });
+    }
+});
+
+describe("computeStatProgression - winrate stat", () => {
+    // Winrate = wins / gamesPlayed, a fraction in [0, 1] whose milestones step
+    // by 5%. Built from `wins` + `gamesPlayed` (not settable directly), and NOT
+    // folded into the shared quotient loop above since that hardcodes
+    // integer-ratio milestones.
+    const gamemodes = ALL_GAMEMODE_KEYS;
+
+    const winrateHistory = (
+        gamemode: GamemodeKey,
+        start: { readonly wins: number; readonly gamesPlayed: number },
+        end: { readonly wins: number; readonly gamesPlayed: number },
+        startDate: Date,
+        endDate: Date,
+    ): History => [
+        new PlayerDataBuilder(TEST_UUID, startDate)
+            .withGamemodeStats(
+                gamemode,
+                new StatsBuilder()
+                    .withStat("wins", start.wins)
+                    .withStat("gamesPlayed", start.gamesPlayed)
+                    .build(),
+            )
+            .build(),
+        new PlayerDataBuilder(TEST_UUID, endDate)
+            .withGamemodeStats(
+                gamemode,
+                new StatsBuilder()
+                    .withStat("wins", end.wins)
+                    .withStat("gamesPlayed", end.gamesPlayed)
+                    .build(),
+            )
+            .build(),
+    ];
+
+    for (const gamemode of gamemodes) {
+        describe(`gamemode: ${gamemode}`, () => {
+            test("improving winrate steps up by 5%", () => {
+                const startDate = new Date("2024-01-01T00:00:00Z");
+                const endDate = new Date("2024-01-11T00:00:00Z"); // 10 days
+
+                // Start 50/100 = 0.5, end 140/200 = 0.7, session 90/100 = 0.9.
+                const result = computeStatProgression(
+                    winrateHistory(
+                        gamemode,
+                        { wins: 50, gamesPlayed: 100 },
+                        { wins: 140, gamesPlayed: 200 },
+                        startDate,
+                        endDate,
+                    ),
+                    endDate,
+                    "winrate",
+                    gamemode,
+                );
+
+                if (result.error) {
+                    expect.unreachable(
+                        `Expected success but got error: ${result.reason}`,
+                    );
+                }
+
+                const {
+                    nextMilestoneValue,
+                    daysUntilMilestone,
+                    progressPerDay,
+                    ...rest
+                } = result;
+
+                expect(rest).toStrictEqual({
+                    stat: "winrate",
+                    endValue: 140 / 200,
+                    sessionQuotient: 90 / 100,
+                    dividendPerDay: 90 / 10,
+                    divisorPerDay: 100 / 10,
+                    trendingUpward: true,
+                    trackingDataTimeInterval: {
+                        start: startDate,
+                        end: endDate,
+                    },
+                });
+
+                // 0.70 -> 0.75 (next 5% step up).
+                expect(nextMilestoneValue).toBeCloseTo(0.75, 9);
+                // t = (M*d0 - k0) / (k - M*d) = (0.75*200 - 140) / (9 - 0.75*10)
+                expect(daysUntilMilestone).toBeCloseTo(20 / 3, 9);
+                expect(progressPerDay).toBeCloseTo((0.75 - 140 / 200) / (20 / 3), 9);
+            });
+
+            test("declining winrate steps down by 5%", () => {
+                const startDate = new Date("2024-01-01T00:00:00Z");
+                const endDate = new Date("2024-01-11T00:00:00Z"); // 10 days
+
+                // Start 160/200 = 0.8, end 175/250 = 0.7, session 15/50 = 0.3.
+                const result = computeStatProgression(
+                    winrateHistory(
+                        gamemode,
+                        { wins: 160, gamesPlayed: 200 },
+                        { wins: 175, gamesPlayed: 250 },
+                        startDate,
+                        endDate,
+                    ),
+                    endDate,
+                    "winrate",
+                    gamemode,
+                );
+
+                if (result.error) {
+                    expect.unreachable(
+                        `Expected success but got error: ${result.reason}`,
+                    );
+                }
+
+                const {
+                    nextMilestoneValue,
+                    daysUntilMilestone,
+                    progressPerDay,
+                    ...rest
+                } = result;
+
+                expect(rest).toStrictEqual({
+                    stat: "winrate",
+                    endValue: 175 / 250,
+                    sessionQuotient: 15 / 50,
+                    dividendPerDay: 15 / 10,
+                    divisorPerDay: 50 / 10,
+                    trendingUpward: false,
+                    trackingDataTimeInterval: {
+                        start: startDate,
+                        end: endDate,
+                    },
+                });
+
+                // 0.70 -> 0.65 (next 5% step down).
+                expect(nextMilestoneValue).toBeCloseTo(0.65, 9);
+                // t = (M*d0 - k0) / (k - M*d) = (0.65*250 - 175) / (1.5 - 0.65*5)
+                expect(daysUntilMilestone).toBeCloseTo(50 / 7, 9);
+                expect(progressPerDay).toBeCloseTo((0.65 - 175 / 250) / (50 / 7), 9);
+            });
+
+            test("perfect record clamps the milestone to 100% and reports it reached", () => {
+                const startDate = new Date("2024-01-01T00:00:00Z");
+                const endDate = new Date("2024-01-11T00:00:00Z"); // 10 days
+
+                // Won every game: 50/50 -> 100/100 = 100%. The 5% step would be
+                // 105%, but it clamps to 100% (== the current value), so there is
+                // no further milestone: reached now (0 days), no NaN.
+                const result = computeStatProgression(
+                    winrateHistory(
+                        gamemode,
+                        { wins: 50, gamesPlayed: 50 },
+                        { wins: 100, gamesPlayed: 100 },
+                        startDate,
+                        endDate,
+                    ),
+                    endDate,
+                    "winrate",
+                    gamemode,
+                );
+
+                if (result.error) {
+                    expect.unreachable(
+                        `Expected success but got error: ${result.reason}`,
+                    );
+                }
+
+                expect(result).toStrictEqual({
+                    stat: "winrate",
+                    endValue: 1,
+                    nextMilestoneValue: 1,
+                    daysUntilMilestone: 0,
+                    progressPerDay: 0,
+                    sessionQuotient: 1,
+                    dividendPerDay: 50 / 10,
+                    divisorPerDay: 50 / 10,
+                    trendingUpward: true,
+                    trackingDataTimeInterval: {
+                        start: startDate,
+                        end: endDate,
+                    },
+                });
+            });
         });
     }
 });
@@ -2200,6 +2392,60 @@ describe(nextNaturalMilestone, () => {
             expected: 0,
         },
 
+        // Winrate: next 5% step in the trend direction.
+        {
+            name: "winrate: up from mid-step",
+            value: 0.72,
+            trendingUpward: true,
+            stat: "winrate",
+            expected: 0.75,
+        },
+        {
+            name: "winrate: up from exact step boundary",
+            value: 0.5,
+            trendingUpward: true,
+            stat: "winrate",
+            expected: 0.55,
+        },
+        {
+            name: "winrate: down from mid-step",
+            value: 0.68,
+            trendingUpward: false,
+            stat: "winrate",
+            expected: 0.65,
+        },
+        {
+            name: "winrate: down from exact step boundary",
+            value: 0.5,
+            trendingUpward: false,
+            stat: "winrate",
+            expected: 0.45,
+        },
+        // Clamped into [0, 1]: a near-perfect record can't project past 100%.
+        // At the clamp boundary the milestone equals `value` (the strict-monotonic
+        // contract's documented exception).
+        {
+            name: "winrate: clamps up to 100% just below the top step",
+            value: 0.98,
+            trendingUpward: true,
+            stat: "winrate",
+            expected: 1,
+        },
+        {
+            name: "winrate: clamps up to 100% at 100% (returns value)",
+            value: 1,
+            trendingUpward: true,
+            stat: "winrate",
+            expected: 1,
+        },
+        {
+            name: "winrate: clamps down to 0% at 0% (returns value)",
+            value: 0,
+            trendingUpward: false,
+            stat: "winrate",
+            expected: 0,
+        },
+
         // Everything else: round number scaled to the order of magnitude.
         {
             name: "index: up small",
@@ -2294,6 +2540,7 @@ describe(nextNaturalMilestone, () => {
         const samples: { value: number; stat: StatKey }[] = [
             { value: 3.5, stat: "fkdr" },
             { value: 4, stat: "kdr" },
+            { value: 0.5, stat: "winrate" },
             { value: 16, stat: "index" },
             { value: 100, stat: "wins" },
             { value: 250, stat: "experience" },


### PR DESCRIPTION
## What

Adds a **winrate** stat (`wins / gamesPlayed`), stored/computed as a fraction in `[0, 1]` but rendered everywhere as a percentage (e.g. `85.4%`): stat cards, sessions table, progression value + milestone + caption, and chart tooltips. On charts the plotted value stays in `[0, 1]`; only tooltip/label **text** shows `%`, and the Y-axis stays numeric.

Because there was no central number formatter (every site called `.toLocaleString(...)` inline), this lands as three commits: build the formatter, extend it to chart tooltips, then add winrate as a small diff on top.

## Commits

1. **`refactor(stats): unify stat-value rendering behind formatStatValue`** — new `src/stats/format.ts` with `formatStatValue` + the exhaustive `STAT_FORMAT_KIND: Record<StatKey, …>` (kinds `integer`/`decimal`). Routes the non-chart stat-value render sites (session cards, sessions-table, progression value/milestone) through it; lifts a module-level `BAD_STATS`; collapses the `ProgressionValueAndMilestone` switch. Behavior-preserving except two documented trailing-zero normalizations (sessions-table decimals → fixed 3dp; progression decimals → min 2dp).
2. **`feat(charts): format history-chart tooltip values by stat kind`** — both chart tooltips go through `formatStatValue`. `HistoryChart` gains a tooltip value formatter fed by an authoritative `dataKey → stat` map built where the `<Line>`s are created (no dataKey string-parsing). Y-axes unchanged.
3. **`feat(stats): add winrate stat rendered as a percentage`** — adds the `winrate` key + the `"percentage"` format kind + compute (`getStat`/`computeStat`) + labels (`Win rate`/`WR`) + progression (quotient family, milestones step by 5%) + session-page wiring + a bespoke caption case + tests.

## Formatting note (floating-point milestones)

The 5%-step milestone math produces non-exact floats internally (e.g. `14 * 0.05 = 0.7000000000000001`). These are only ever used for progress calculation and comparison — **never rendered raw**. Every rendered winrate value (cards, table, progression value + milestone + caption, both chart tooltips) goes through `formatStatValue("winrate", …)`, which formats via `Intl` (`toLocaleString(…, { style: "percent", maximumFractionDigits })`, locale-aware) at a fixed number of decimals (`min = max`, like the decimal case): 1 in `compact` contexts, 2 in `detailed` — so `0.7000000000000001` renders as `70.0%`, and `0.6333…` as `63.3%` (compact) / `63.33%` (detailed).

Milestones are clamped into `[0, 1]`, so a perfect (100%) or all-losses (0%) record can't project past its bound; when the clamped milestone equals the current value it is reported as already reached (0 days) rather than dividing 0/0.

## No cache-buster bump

Winrate is derived and changes no cached `PlayerDataPIT` type; the only touched persisted surface is the `z.enum(ALL_STAT_KEYS)` URL param, which is not cached query data.

## Preview

Open the same page on both and compare. On each, search a player, then select **Win rate** (staging — the new stat) or an existing ratio like **WLR** (current — to sanity-check that tooltips / sessions table / stat cards still render identically after commits 1–2). Winrate is a **new** stat, so it only appears on the staging column.

| Page | Current app (production) | Staging (this PR) |
|------|--------------------------|-------------------|
| Session | https://prismoverlay.com/session | https://add-winrate-stat.rainbow-ctx.pages.dev/session |
| History explorer | https://prismoverlay.com/history/explore | https://add-winrate-stat.rainbow-ctx.pages.dev/history/explore |

<sub>Staging is the Cloudflare Pages branch preview for `add-winrate-stat` (tracks the branch head; this-commit pin: https://bd5614a8.rainbow-ctx.pages.dev).</sub>

## Test plan

- [x] `pnpm tsc` (app) + `pnpm tsc:node` (tests) — clean. The `Record<StatKey>` format map, the no-default label switches, and `computeStatProgression`'s `satisfies never` force every required edit.
- [x] `pnpm lint:check` — clean (oxfmt + oxlint).
- [x] `pnpm test:unit` — 770 pass (incl. dedicated winrate progression cases: up/down 5% steps across all gamemodes, plus `nextNaturalMilestone` winrate cases).
- [x] `pnpm test` (browser) — 971 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

