### PR TITLE
feat(stats): try collapsed rendering of large integers (1,123M)

### DIFF
--- a/src/charts/history/chart.tsx
+++ b/src/charts/history/chart.tsx
@@ -342,7 +342,10 @@ export const HistoryChart: React.FC<HistoryChartProps> = ({
                 formatter={(value, _name, item) => {
                     const stat = statByDataKey.get(String(item.dataKey));
                     return typeof value === "number" && stat !== undefined
-                        ? formatStatValue(stat, value, { precision: "detailed" })
+                        ? formatStatValue(stat, value, {
+                              precision: "detailed",
+                              notation: "collapsed",
+                          })
                         : value;
                 }}
                 contentStyle={{
@@ -504,7 +507,10 @@ export const SimpleHistoryChart: React.FC<SimpleHistoryChartProps> = ({
                         return null;
                     }
 
-                    return formatStatValue(stat, value, { precision: "detailed" });
+                    return formatStatValue(stat, value, {
+                        precision: "detailed",
+                        notation: "collapsed",
+                    });
                 }}
                 contentStyle={{
                     backgroundColor: theme.palette.background.paper,

--- a/src/routes/session/$uuid.tsx
+++ b/src/routes/session/$uuid.tsx
@@ -482,6 +482,7 @@ const Sessions: React.FC<SessionsProps> = ({
 
                                             return formatStatValue(statKey, value, {
                                                 precision: "detailed",
+                                                notation: "collapsed",
                                             });
                                         };
 
@@ -808,19 +809,23 @@ const SessionStatCard: React.FC<SessionStatCardProps> = ({
                             <Typography variant="body1">
                                 {formatStatValue(stat, sessionValue, {
                                     precision: "detailed",
+                                    notation: "collapsed",
                                 })}
                             </Typography>
                             <Tooltip
                                 title={`${formatStatValue(stat, startValue, {
                                     precision: "detailed",
+                                    notation: "collapsed",
                                 })} → ${formatStatValue(stat, endValue, {
                                     precision: "detailed",
+                                    notation: "collapsed",
                                 })}`}
                             >
                                 <Stack direction="row" gap={0.5} alignItems="center">
                                     <Typography variant="caption" color={trendColor}>
                                         {formatStatValue(stat, diff, {
                                             signDisplay: "always",
+                                            notation: "collapsed",
                                         })}
                                     </Typography>
                                     {diff > 0 && (
@@ -910,7 +915,7 @@ const ProgressionValueAndMilestone: React.FC<ProgressionValueAndMilestoneProps> 
         progression.nextMilestoneValue,
         (value) => (
             <Typography variant="body1">
-                {formatStatValue(progression.stat, value)}
+                {formatStatValue(progression.stat, value, { notation: "collapsed" })}
             </Typography>
         ),
         BAD_STATS.includes(progression.stat),

--- a/src/stats/format.ts
+++ b/src/stats/format.ts
@@ -28,19 +28,84 @@ export const STAT_FORMAT_KIND: Record<StatKey, StatFormatKind> = {
 export const getStatFormatKind = (stat: StatKey): StatFormatKind =>
     STAT_FORMAT_KIND[stat];
 
+// --- Collapsed notation for large magnitudes --------------------------------
+// Large integer stats (index, experience, lifetime kill/win counts) render as
+// long digit strings ("1.123.123") that are hard to scan at a glance. In
+// "collapsed" notation we shorten them to a mantissa + a single-letter
+// magnitude suffix, keeping the locale's own decimal separator:
+//   1_123_123     -> "1,123M" (nb-NO)  / "1.123M" (en-US)
+//   45_000        -> "45K"
+//   2_500_000_000 -> "2,5B"
+// The suffix stays Latin (K/M/B/T) rather than the locale-spelled form
+// ("mill.") that `Intl` compact notation would produce, so the shape is stable
+// across locales. Only magnitudes at/above the smallest tier collapse; smaller
+// values fall through to the normal per-kind formatting, so "42 wins" is left
+// as "42".
+const COLLAPSE_TIERS = [
+    { threshold: 1e12, suffix: "T" },
+    { threshold: 1e9, suffix: "B" },
+    { threshold: 1e6, suffix: "M" },
+    { threshold: 1e3, suffix: "K" },
+] as const;
+
+const SMALLEST_COLLAPSE_TIER = 1e3;
+
+const formatCollapsed = (
+    value: number,
+    maximumFractionDigits: number,
+    signDisplay: Intl.NumberFormatOptions["signDisplay"],
+): string => {
+    const tier = COLLAPSE_TIERS.find(({ threshold }) => Math.abs(value) >= threshold);
+    if (tier === undefined) {
+        // Callers gate on `>= SMALLEST_COLLAPSE_TIER`, so this is unreachable;
+        // fall back to a plain integer render to stay safe.
+        return value.toLocaleString(undefined, {
+            maximumFractionDigits: 0,
+            signDisplay,
+        });
+    }
+    // `maximumFractionDigits` (with the implicit `minimumFractionDigits: 0`)
+    // trims trailing zeros, so an exact tier renders as "2M", not "2,00M".
+    const mantissa = (value / tier.threshold).toLocaleString(undefined, {
+        maximumFractionDigits,
+        signDisplay,
+    });
+    return `${mantissa}${tier.suffix}`;
+};
+
 interface FormatStatValueOptions {
     // "compact" → cards / diffs / short contexts (fewer decimals);
     // "detailed" → values / tooltips / hover detail (more decimals).
     readonly precision?: "compact" | "detailed";
+    // "collapsed" shortens large magnitudes to a mantissa + K/M/B/T suffix (see
+    // `formatCollapsed`). "standard" (the default) keeps full digit grouping.
+    readonly notation?: "standard" | "collapsed";
     readonly signDisplay?: Intl.NumberFormatOptions["signDisplay"];
 }
 
 export const formatStatValue = (
     stat: StatKey,
     value: number,
-    { precision = "compact", signDisplay }: FormatStatValueOptions = {},
+    {
+        precision = "compact",
+        notation = "standard",
+        signDisplay,
+    }: FormatStatValueOptions = {},
 ): string => {
-    switch (getStatFormatKind(stat)) {
+    const kind = getStatFormatKind(stat);
+
+    // Collapse only genuinely large magnitudes. Percentages are bounded in
+    // practice (a winrate never leaves [0, 1]), so they always keep their own
+    // formatting and never grow a K/M suffix.
+    if (
+        notation === "collapsed" &&
+        kind !== "percentage" &&
+        Math.abs(value) >= SMALLEST_COLLAPSE_TIER
+    ) {
+        return formatCollapsed(value, precision === "detailed" ? 3 : 2, signDisplay);
+    }
+
+    switch (kind) {
         case "decimal": {
             const digits = precision === "detailed" ? 3 : 2;
             return value.toLocaleString(undefined, {

--- a/src/stats/format.unit.test.ts
+++ b/src/stats/format.unit.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "vitest";
+
+import { formatStatValue } from "./format.ts";
+
+// `toLocaleString` uses the runtime's default locale, so the decimal separator
+// is environment-dependent (a comma in nb-NO, a dot in en-US). Assertions that
+// span the separator therefore accept either character instead of hard-coding
+// one, while the collapse logic under test (tier selection, suffix, threshold
+// gating, sign handling) is locale-independent.
+const sep = "[.,]";
+
+describe("formatStatValue collapsed notation", () => {
+    test("collapses millions to an M suffix (the motivating case)", () => {
+        // 1_123_123 -> "1,123M" (nb) / "1.123M" (en)
+        expect(
+            formatStatValue("index", 1_123_123, {
+                notation: "collapsed",
+                precision: "detailed",
+            }),
+        ).toMatch(new RegExp(`^1${sep}123M$`));
+    });
+
+    test("picks the right tier per magnitude", () => {
+        expect(formatStatValue("index", 45_000, { notation: "collapsed" })).toBe("45K");
+        expect(formatStatValue("index", 2_500_000, { notation: "collapsed" })).toMatch(
+            new RegExp(`^2${sep}5M$`),
+        );
+        expect(
+            formatStatValue("index", 2_500_000_000, { notation: "collapsed" }),
+        ).toMatch(new RegExp(`^2${sep}5B$`));
+        expect(
+            formatStatValue("index", 12_000_000_000_000, { notation: "collapsed" }),
+        ).toBe("12T");
+    });
+
+    test("trims trailing zeros on exact tiers", () => {
+        expect(formatStatValue("index", 1_000_000, { notation: "collapsed" })).toBe(
+            "1M",
+        );
+        expect(formatStatValue("index", 1000, { notation: "collapsed" })).toBe("1K");
+    });
+
+    test("does not collapse below the smallest tier", () => {
+        expect(formatStatValue("index", 999, { notation: "collapsed" })).toBe("999");
+        expect(formatStatValue("index", 0, { notation: "collapsed" })).toBe("0");
+    });
+
+    test("carries a smaller mantissa in compact vs detailed precision", () => {
+        // compact -> 2 fraction digits, detailed -> 3.
+        expect(
+            formatStatValue("index", 1_123_400, {
+                notation: "collapsed",
+                precision: "compact",
+            }),
+        ).toMatch(new RegExp(`^1${sep}12M$`));
+        expect(
+            formatStatValue("index", 1_123_400, {
+                notation: "collapsed",
+                precision: "detailed",
+            }),
+        ).toMatch(new RegExp(`^1${sep}123M$`));
+    });
+
+    test("honours signDisplay and negatives", () => {
+        expect(
+            formatStatValue("index", 1_200_000, {
+                notation: "collapsed",
+                signDisplay: "always",
+            }),
+        ).toMatch(new RegExp(`^\\+1${sep}2M$`));
+        expect(formatStatValue("index", -1_200_000, { notation: "collapsed" })).toMatch(
+            new RegExp(`^-1${sep}2M$`),
+        );
+    });
+
+    test("collapses large decimal-kind stats too", () => {
+        expect(formatStatValue("fkdr", 1500, { notation: "collapsed" })).toMatch(
+            new RegExp(`^1${sep}5K$`),
+        );
+    });
+
+    test("leaves small decimal-kind stats to standard formatting", () => {
+        expect(
+            formatStatValue("fkdr", 5.25, {
+                notation: "collapsed",
+                precision: "detailed",
+            }),
+        ).toBe(formatStatValue("fkdr", 5.25, { precision: "detailed" }));
+    });
+
+    test("never collapses percentage-kind stats", () => {
+        expect(formatStatValue("winrate", 0.734, { notation: "collapsed" })).toBe(
+            formatStatValue("winrate", 0.734),
+        );
+    });
+});
+
+describe("formatStatValue standard notation is unchanged", () => {
+    test("integers keep full digit grouping by default", () => {
+        expect(formatStatValue("index", 1_123_123)).toBe(
+            (1_123_123).toLocaleString(undefined, { maximumFractionDigits: 0 }),
+        );
+        // No magnitude suffix leaks into the default rendering.
+        expect(formatStatValue("index", 1_123_123)).not.toMatch(/[KMBT]$/);
+    });
+
+    test("explicitly requesting standard notation matches the default", () => {
+        expect(formatStatValue("index", 1_123_123, { notation: "standard" })).toBe(
+            formatStatValue("index", 1_123_123),
+        );
+    });
+});


### PR DESCRIPTION
## What

Tries out **"collapsed" rendering of large integers**: instead of a long digit string like `1.123.123` (the `index` stat, in a comma-grouping locale), large stat values render as a mantissa + a single-letter magnitude suffix — `1,123M` (nb-NO) / `1.123M` (en-US).

Built as an extension to the central `formatStatValue` (the formatter introduced in #316), so it slots in as a new option rather than a new code path per call site.

## How it works

`formatStatValue` gains a `notation: "standard" | "collapsed"` option (default `"standard"`, so **every existing call is byte-for-byte unchanged**). In `"collapsed"` notation, a magnitude at or above `1,000` is shortened to a mantissa + tier suffix (`K`/`M`/`B`/`T`), keeping the locale's own decimal separator:

| value | collapsed (detailed / 3dp) |
|------:|:---------------------------|
| `999` | `999` (below the smallest tier — unchanged) |
| `1_000` | `1K` |
| `45_000` | `45K` |
| `1_123_123` | `1,123M` (nb) / `1.123M` (en) |
| `2_500_000` | `2,5M` |
| `2_500_000_000` | `2,5B` |
| `12_000_000_000_000` | `12T` |
| `-1_200_000` | `-1,2M` |

Design notes:

- **Latin suffix, not the locale-spelled form.** `Intl`'s own compact notation emits `1,1 mill.` in `nb-NO`; we keep a stable `K/M/B/T` across locales (matching the `1,123M` in the ask) while still formatting the mantissa locale-aware.
- **Fraction digits reuse the existing `precision` option** — 2 (`compact`) / 3 (`detailed`) — with trailing zeros trimmed, so an exact tier reads as `2M`, not `2,00M`.
- **Only large magnitudes collapse.** Below `1,000`, and for percentage-kind stats (a winrate never leaves `[0, 1]`), the value falls through to the unchanged per-kind formatting — so `42 wins` stays `42`.

## Commits

1. **`feat(stats): add collapsed notation to formatStatValue`** — the `notation` option + `formatCollapsed` tier logic, plus a locale-robust `format.unit.test.ts`.
2. **`feat(session,charts): render large stat values in collapsed notation`** — opts every single-stat scalar render site into `notation: "collapsed"`: the session-detail stat-card value / start→end tooltip / diff, the sessions table, the progression value + milestone, and both history-chart tooltips. The shared multi-line Y-axis is left untouched (it can plot several stats at once, so there is no single format kind to collapse against).

## Known rough edge

At `compact` precision (2dp), a value like `999_999` rounds its mantissa up to `1,000K` rather than promoting to `1M`. It's a narrow band just under each tier boundary and only at 2dp; left as-is for this "try it out" pass.

## Preview

Search a player with a big **Index** (`FKDR² × stars`), then compare against production. The collapse shows up on the stat-card value, the sessions table, the progression row, and chart tooltips.

| Page | Current (production) | Staging (this PR) |
|------|----------------------|-------------------|
| Session | https://prismoverlay.com/session | https://collapsed-large-integers.rainbow-ctx.pages.dev/session |
| History explorer | https://prismoverlay.com/history/explore | https://collapsed-large-integers.rainbow-ctx.pages.dev/history/explore |

<sub>Staging is the Cloudflare Pages branch preview for `collapsed-large-integers` (tracks the branch head).</sub>

## Test plan

- [x] `pnpm tsc` (app) + `pnpm tsc:node` (tests) — clean.
- [x] `pnpm lint:check` — clean (oxfmt + oxlint).
- [x] `pnpm test:unit` — 790 pass (incl. the new collapsed-notation cases: tier selection, threshold gating, sign/negatives, precision fraction digits, percentage never collapsing, and standard notation unchanged).
- [x] `pnpm test:ui` — 201 pass (session detail + history explore render sites unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
