### PR TITLE
Send X-Client-Type/X-Client-Version headers to flashlight

### DIFF
--- a/src/helpers/flashlight.ts
+++ b/src/helpers/flashlight.ts
@@ -1,0 +1,19 @@
+import { getOrSetUserId } from "#helpers/userId.ts";
+
+// Client identification headers consumed by the flashlight backend. rainbow is
+// evergreen (always served from the latest deploy), so it always reports the
+// "evergreen" version. See https://github.com/Amund211/flashlight/pull/328.
+//
+// IMPORTANT: These headers identify us to flashlight and must ONLY be sent to
+// the flashlight API. Do not attach them to requests to any other server.
+const CLIENT_TYPE = "rainbow";
+const CLIENT_VERSION = "evergreen";
+
+// getFlashlightHeaders returns the headers to send with every request to the
+// flashlight API. Centralizing them here keeps the client identification
+// consistent across call sites and ensures they are only sent to flashlight.
+export const getFlashlightHeaders = (): Record<string, string> => ({
+    "X-User-Id": getOrSetUserId(),
+    "X-Client-Type": CLIENT_TYPE,
+    "X-Client-Version": CLIENT_VERSION,
+});

--- a/src/helpers/flashlight.unit.test.ts
+++ b/src/helpers/flashlight.unit.test.ts
@@ -1,0 +1,18 @@
+import { test, expect, describe } from "vitest";
+
+import { getFlashlightHeaders } from "./flashlight.ts";
+
+describe(getFlashlightHeaders, () => {
+    test("identifies rainbow as the client", () => {
+        const headers = getFlashlightHeaders();
+
+        expect(headers["X-Client-Type"]).toBe("rainbow");
+        expect(headers["X-Client-Version"]).toBe("evergreen");
+    });
+
+    test("includes the user id", () => {
+        const headers = getFlashlightHeaders();
+
+        expect(headers["X-User-Id"]).toMatch(/^rnb_/);
+    });
+});

--- a/src/queries/history.ts
+++ b/src/queries/history.ts
@@ -2,7 +2,7 @@ import { captureException, captureMessage } from "@sentry/react";
 import { queryOptions } from "@tanstack/react-query";
 
 import { env } from "#env.ts";
-import { getOrSetUserId } from "#helpers/userId.ts";
+import { getFlashlightHeaders } from "#helpers/flashlight.ts";
 import { isNormalizedUUID } from "#helpers/uuid.ts";
 import { MS_PER_MINUTE } from "#time.ts";
 
@@ -66,7 +66,7 @@ export const getHistoryQueryOptions = ({
                 {
                     headers: {
                         "Content-Type": "application/json",
-                        "X-User-Id": getOrSetUserId(),
+                        ...getFlashlightHeaders(),
                     },
                     method: "POST",
                     body: JSON.stringify({

--- a/src/queries/sessionAt.ts
+++ b/src/queries/sessionAt.ts
@@ -2,7 +2,7 @@ import { captureException, captureMessage } from "@sentry/react";
 import { queryOptions } from "@tanstack/react-query";
 
 import { env } from "#env.ts";
-import { getOrSetUserId } from "#helpers/userId.ts";
+import { getFlashlightHeaders } from "#helpers/flashlight.ts";
 import { isNormalizedUUID } from "#helpers/uuid.ts";
 import { ALL_GAMEMODE_KEYS } from "#stats/keys.ts";
 import type { GamemodeKey } from "#stats/keys.ts";
@@ -147,7 +147,7 @@ export const getSessionAtQueryOptions = ({ uuid, time }: SessionAtQueryOptions) 
                 {
                     headers: {
                         "Content-Type": "application/json",
-                        "X-User-Id": getOrSetUserId(),
+                        ...getFlashlightHeaders(),
                     },
                     method: "POST",
                     body: JSON.stringify({ uuid, time: timeISOString }),

--- a/src/queries/sessions.ts
+++ b/src/queries/sessions.ts
@@ -2,7 +2,7 @@ import { captureException, captureMessage } from "@sentry/react";
 import { queryOptions } from "@tanstack/react-query";
 
 import { env } from "#env.ts";
-import { getOrSetUserId } from "#helpers/userId.ts";
+import { getFlashlightHeaders } from "#helpers/flashlight.ts";
 import { isNormalizedUUID } from "#helpers/uuid.ts";
 import { MS_PER_MINUTE } from "#time.ts";
 
@@ -84,7 +84,7 @@ export const getSessionsQueryOptions = ({ uuid, start, end }: SessionsQueryOptio
                 {
                     headers: {
                         "Content-Type": "application/json",
-                        "X-User-Id": getOrSetUserId(),
+                        ...getFlashlightHeaders(),
                     },
                     method: "POST",
                     body: JSON.stringify({

--- a/src/queries/username.ts
+++ b/src/queries/username.ts
@@ -3,7 +3,7 @@ import { queryOptions, useQueries } from "@tanstack/react-query";
 
 import { addKnownAliasAndPersist } from "#contexts/KnownAliases/helpers.ts";
 import { env } from "#env.ts";
-import { getOrSetUserId } from "#helpers/userId.ts";
+import { getFlashlightHeaders } from "#helpers/flashlight.ts";
 import { isNormalizedUUID } from "#helpers/uuid.ts";
 import { MS_PER_HOUR } from "#time.ts";
 
@@ -33,9 +33,7 @@ export const getUsernameQueryOptions = (uuid: string) =>
                 //       Reach out on Discord for more information. https://discord.gg/k4FGUnEHYg
                 `${env.VITE_FLASHLIGHT_URL}/v1/account/uuid/${uuid}`,
                 {
-                    headers: {
-                        "X-User-Id": getOrSetUserId(),
-                    },
+                    headers: getFlashlightHeaders(),
                 },
             ).catch((error: unknown) => {
                 captureException(error, {

--- a/src/queries/uuid.ts
+++ b/src/queries/uuid.ts
@@ -3,7 +3,7 @@ import { queryOptions } from "@tanstack/react-query";
 
 import { addKnownAliasAndPersist } from "#contexts/KnownAliases/helpers.ts";
 import { env } from "#env.ts";
-import { getOrSetUserId } from "#helpers/userId.ts";
+import { getFlashlightHeaders } from "#helpers/flashlight.ts";
 import { normalizeUUID } from "#helpers/uuid.ts";
 import { MS_PER_DAY } from "#time.ts";
 
@@ -23,9 +23,7 @@ export const getUUIDQueryOptions = (username: string) =>
                 //       Reach out on Discord for more information. https://discord.gg/k4FGUnEHYg
                 `${env.VITE_FLASHLIGHT_URL}/v1/account/username/${username}`,
                 {
-                    headers: {
-                        "X-User-Id": getOrSetUserId(),
-                    },
+                    headers: getFlashlightHeaders(),
                 },
             ).catch((error: unknown) => {
                 captureException(error, {

--- a/src/queries/wrapped.ts
+++ b/src/queries/wrapped.ts
@@ -2,7 +2,7 @@ import { captureException, captureMessage } from "@sentry/react";
 import { queryOptions } from "@tanstack/react-query";
 
 import { env } from "#env.ts";
-import { getOrSetUserId } from "#helpers/userId.ts";
+import { getFlashlightHeaders } from "#helpers/flashlight.ts";
 import { isNormalizedUUID } from "#helpers/uuid.ts";
 import { MS_PER_MINUTE } from "#time.ts";
 
@@ -194,7 +194,7 @@ export const getWrappedQueryOptions = ({
             const response = await fetch(url, {
                 headers: {
                     "Content-Type": "application/json",
-                    "X-User-Id": getOrSetUserId(),
+                    ...getFlashlightHeaders(),
                 },
                 method: "GET",
             }).catch((error: unknown) => {


### PR DESCRIPTION
## Context

[flashlight#328](https://github.com/Amund211/flashlight/pull/328) moves client identification off the free-form `User-Agent` string onto two dedicated, low-cardinality headers:

- `X-Client-Type` → `prism` / `rainbow` / `unknown` / `missing`
- `X-Client-Version` → an allowlisted version / `evergreen` / `unknown` / `missing`

The backend validates the `(type, version)` pair jointly, and `rainbow` only ever passes as `(rainbow, evergreen)` — anything else collapses to `unknown/unknown`. This PR makes rainbow send that pair.

## What's here

- **New `getFlashlightHeaders()` helper** (`src/helpers/flashlight.ts`) returning `X-User-Id`, `X-Client-Type: rainbow`, and `X-Client-Version: evergreen`. Centralizing the flashlight request headers here keeps them consistent across call sites and ensures they can never leak to another server.
- **All six flashlight call sites** now use the helper: `uuid`, `username`, `sessions`, `sessionAt`, `history`, `wrapped`.
- **Unit test** locking in the exact header values.

### Only sent to flashlight

rainbow makes no `fetch`/`axios`/`XHR` calls to anything other than flashlight (Sentry uses its own SDK), and the helper is the single source of these headers — so nothing else can pick them up.

## Verification

- `pnpm tsc` ✅
- `pnpm lint:check` (oxlint + oxfmt) ✅
- `pnpm test:unit` → 914 passed ✅
- `pnpm test:ui:chromium` → 208 passed ✅

## Note

Depends on flashlight#328 being merged/deployed. The backend allowlists `(rainbow, evergreen)`, so sending it early is harmless, but there is no benefit until the backend reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)