### PR TITLE
chore: gitignore sandbox-injected files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,14 @@ dist-ssr
 # Claude config
 /.claude/*
 /.mcp.json
+
+# Sandbox-injected files (shell/editor configs mounted into the working tree)
+/.bash_profile
+/.bashrc
+/.gitconfig
+/.gitmodules
+/.profile
+/.ripgreprc
+/.vscode
+/.zprofile
+/.zshrc


### PR DESCRIPTION
## Summary
The sandbox environment mounts shell/editor config files into the working tree as char devices (`/dev/null` bind-mounts), which show up as untracked in `git status`:

- `.bash_profile`, `.bashrc`, `.gitconfig`, `.gitmodules`, `.profile`, `.ripgreprc`, `.zprofile`, `.zshrc`
- `.vscode` (now a char device, not caught by the existing `.vscode/*` pattern)

This adds them to `.gitignore` so `git status` stays clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)