### PR TITLE
feat(auth): anonymous sessions against flashlight

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -169,7 +169,10 @@
                             "HTMLElement",
                             "CustomEvent",
                             "StorageEvent",
-                            "IDBValidKey"
+                            "IDBValidKey",
+                            "MessageEvent",
+                            "Worker",
+                            "Uint8Array"
                         ]
                     },
                     {

--- a/src/helpers/flashlight/auth/api.ts
+++ b/src/helpers/flashlight/auth/api.ts
@@ -1,0 +1,116 @@
+import { captureMessage } from "@sentry/react";
+
+import {
+    FlashlightResponseError,
+    flashlightRequest,
+} from "#helpers/flashlight/request.ts";
+
+import type { Challenge } from "./proofOfWork.ts";
+import { isTier, validateSessionId } from "./storage.ts";
+import type { Session } from "./storage.ts";
+
+export interface APIChallengeResponse {
+    readonly challenge: string;
+    readonly algorithm: string;
+    readonly difficulty: number;
+    readonly expiresInSeconds: number;
+}
+
+export interface APISessionResponse {
+    readonly sessionId: string;
+    readonly tier: string;
+    readonly expiresInSeconds: number;
+    readonly refreshUntilInSeconds: number;
+    readonly refreshInSeconds: number;
+    readonly canRefresh: boolean;
+}
+
+// rainbow is reactive-only, so the timing fields are not stored. The session id
+// and the tier are all a page load needs.
+const toSession = (response: APISessionResponse): Session => {
+    if (!validateSessionId(response.sessionId)) {
+        throw new Error("Invalid session id in the flashlight auth response");
+    }
+    if (!isTier(response.tier)) {
+        captureMessage("Unknown tier in the flashlight auth response", {
+            level: "error",
+            extra: { tier: response.tier },
+        });
+        return { sessionId: response.sessionId, tier: "anonymous" };
+    }
+    return { sessionId: response.sessionId, tier: response.tier };
+};
+
+export const requestChallenge = async (userId: string): Promise<Challenge> => {
+    const { data } = await flashlightRequest<APIChallengeResponse>(
+        "/v1/auth/anonymous/challenge",
+        {
+            init: { method: "POST", body: JSON.stringify({ userId }) },
+            errorContext: "Failed to get an auth challenge",
+            extra: { userId },
+        },
+    );
+    return {
+        challenge: data.challenge,
+        algorithm: data.algorithm,
+        difficulty: data.difficulty,
+    };
+};
+
+interface LoginOptions {
+    readonly userId: string;
+    readonly challenge: string;
+    readonly solution: string;
+}
+
+export const anonymousLogin = async ({
+    userId,
+    challenge,
+    solution,
+}: LoginOptions): Promise<Session> => {
+    const { data } = await flashlightRequest<APISessionResponse>(
+        "/v1/auth/anonymous/login",
+        {
+            init: {
+                method: "POST",
+                body: JSON.stringify({ userId, challenge, solution }),
+            },
+            errorContext: "Failed to log in anonymously",
+            extra: { userId },
+        },
+    );
+    return toSession(data);
+};
+
+/**
+ * Refresh a session.
+ *
+ * Returns the refreshed session, `session` unchanged on a 429 (refreshed too
+ * recently, or rate limited — the session is untouched and must be reused), or
+ * null on a 401 (the session is finished; re-auth from scratch).
+ */
+export const refreshSession = async (session: Session): Promise<Session | null> => {
+    try {
+        const { data } = await flashlightRequest<APISessionResponse>(
+            "/v1/auth/refresh",
+            {
+                init: { method: "POST" },
+                errorContext: "Failed to refresh the session",
+                extra: { tier: session.tier },
+                bearer: session.sessionId,
+                expectedStatuses: [401, 429],
+            },
+        );
+        return toSession(data);
+    } catch (error: unknown) {
+        if (error instanceof FlashlightResponseError) {
+            if (error.status === 401) {
+                return null;
+            }
+            if (error.status === 429) {
+                return session;
+            }
+        }
+        throw error;
+    }
+};

--- a/src/helpers/flashlight/auth/auth.ui.test.tsx
+++ b/src/helpers/flashlight/auth/auth.ui.test.tsx
@@ -1,0 +1,199 @@
+import { http, HttpResponse } from "msw";
+import { describe, expect } from "vitest";
+
+import { flashlightFetch } from "#helpers/flashlight/fetch.ts";
+import { makeSessionResponse, TEST_SESSION_ID } from "#mocks/data.ts";
+import { mswTest } from "#test/msw-test.ts";
+
+import { readSession, writeSession } from "./storage.ts";
+
+const endpoint = (path: string) => `http://localhost:5173/flashlight/${path}`;
+
+const fetchThing = async () =>
+    flashlightFetch<{ ok: boolean }>("/v1/thing", {
+        errorContext: "Failed to get thing",
+        extra: {},
+    });
+
+describe("anonymous auth", () => {
+    mswTest(
+        "logs in and sends the bearer when nothing is stored",
+        async ({ worker }) => {
+            const bearers: (string | null)[] = [];
+            worker.use(
+                http.get(endpoint("v1/thing"), ({ request }) => {
+                    bearers.push(request.headers.get("Authorization"));
+                    return HttpResponse.json({ ok: true });
+                }),
+            );
+
+            await expect(fetchThing()).resolves.toStrictEqual({ ok: true });
+
+            expect(bearers).toStrictEqual([`Bearer ${TEST_SESSION_ID}`]);
+            expect(readSession()).toStrictEqual({
+                sessionId: TEST_SESSION_ID,
+                tier: "anonymous",
+            });
+        },
+    );
+
+    mswTest("refreshes and retries on a 401", async ({ worker }) => {
+        writeSession({ sessionId: "flsess_stale", tier: "anonymous" });
+
+        const bearers: (string | null)[] = [];
+        let refreshes = 0;
+        worker.use(
+            http.post(endpoint("v1/auth/refresh"), () => {
+                refreshes++;
+                return HttpResponse.json(makeSessionResponse("flsess_fresh"));
+            }),
+            http.get(endpoint("v1/thing"), ({ request }) => {
+                const bearer = request.headers.get("Authorization");
+                bearers.push(bearer);
+                if (bearer === "Bearer flsess_stale") {
+                    return new HttpResponse(null, { status: 401 });
+                }
+                return HttpResponse.json({ ok: true });
+            }),
+        );
+
+        await expect(fetchThing()).resolves.toStrictEqual({ ok: true });
+
+        expect(refreshes).toBe(1);
+        expect(bearers).toStrictEqual(["Bearer flsess_stale", "Bearer flsess_fresh"]);
+        expect(readSession()?.sessionId).toBe("flsess_fresh");
+    });
+
+    mswTest("logs in again when the refresh 401s", async ({ worker }) => {
+        writeSession({ sessionId: "flsess_dead", tier: "anonymous" });
+
+        const bearers: (string | null)[] = [];
+        let logins = 0;
+        worker.use(
+            http.post(
+                endpoint("v1/auth/refresh"),
+                () => new HttpResponse(null, { status: 401 }),
+            ),
+            http.post(endpoint("v1/auth/anonymous/login"), () => {
+                logins++;
+                return HttpResponse.json(makeSessionResponse());
+            }),
+            http.get(endpoint("v1/thing"), ({ request }) => {
+                const bearer = request.headers.get("Authorization");
+                bearers.push(bearer);
+                if (bearer === "Bearer flsess_dead") {
+                    return new HttpResponse(null, { status: 401 });
+                }
+                return HttpResponse.json({ ok: true });
+            }),
+        );
+
+        await expect(fetchThing()).resolves.toStrictEqual({ ok: true });
+
+        expect(logins).toBe(1);
+        expect(bearers).toStrictEqual([
+            "Bearer flsess_dead",
+            `Bearer ${TEST_SESSION_ID}`,
+        ]);
+    });
+
+    mswTest("clears the stored session when the refresh 401s", async ({ worker }) => {
+        writeSession({ sessionId: "flsess_dead", tier: "anonymous" });
+
+        worker.use(
+            http.post(
+                endpoint("v1/auth/refresh"),
+                () => new HttpResponse(null, { status: 401 }),
+            ),
+            http.post(
+                endpoint("v1/auth/anonymous/login"),
+                () => new HttpResponse(null, { status: 503 }),
+            ),
+            http.get(
+                endpoint("v1/thing"),
+                () => new HttpResponse(null, { status: 401 }),
+            ),
+        );
+
+        await expect(fetchThing()).rejects.toThrow("Failed to log in anonymously");
+
+        expect(readSession()).toBeNull();
+    });
+
+    mswTest("keeps the stored session when the refresh 429s", async ({ worker }) => {
+        writeSession({ sessionId: "flsess_throttled", tier: "anonymous" });
+
+        const bearers: (string | null)[] = [];
+        let logins = 0;
+        worker.use(
+            http.post(
+                endpoint("v1/auth/refresh"),
+                () => new HttpResponse(null, { status: 429 }),
+            ),
+            http.post(endpoint("v1/auth/anonymous/login"), () => {
+                logins++;
+                return HttpResponse.json(makeSessionResponse());
+            }),
+            http.get(endpoint("v1/thing"), ({ request }) => {
+                bearers.push(request.headers.get("Authorization"));
+                // Only the first attempt 401s: the throttled refresh means the
+                // session is still good.
+                if (bearers.length === 1) {
+                    return new HttpResponse(null, { status: 401 });
+                }
+                return HttpResponse.json({ ok: true });
+            }),
+        );
+
+        await expect(fetchThing()).resolves.toStrictEqual({ ok: true });
+
+        expect(logins).toBe(0);
+        expect(bearers).toStrictEqual([
+            "Bearer flsess_throttled",
+            "Bearer flsess_throttled",
+        ]);
+        expect(readSession()?.sessionId).toBe("flsess_throttled");
+    });
+
+    mswTest("logs in once for a concurrent fan-out", async ({ worker }) => {
+        let logins = 0;
+        let challenges = 0;
+        worker.use(
+            http.post(endpoint("v1/auth/anonymous/challenge"), () => {
+                challenges++;
+                return HttpResponse.json({
+                    challenge: "challenge",
+                    algorithm: "sha256-leading-zeros-v1",
+                    difficulty: 0,
+                    expiresInSeconds: 60,
+                });
+            }),
+            http.post(endpoint("v1/auth/anonymous/login"), () => {
+                logins++;
+                return HttpResponse.json(makeSessionResponse());
+            }),
+            http.get(endpoint("v1/thing"), () => HttpResponse.json({ ok: true })),
+        );
+
+        await Promise.all([fetchThing(), fetchThing(), fetchThing()]);
+
+        expect(challenges).toBe(1);
+        expect(logins).toBe(1);
+    });
+
+    mswTest("discards a corrupted stored session", async ({ worker }) => {
+        localStorage.setItem("rainbow_auth_session", '{"v":1,"sessionId":"nope"}');
+
+        const bearers: (string | null)[] = [];
+        worker.use(
+            http.get(endpoint("v1/thing"), ({ request }) => {
+                bearers.push(request.headers.get("Authorization"));
+                return HttpResponse.json({ ok: true });
+            }),
+        );
+
+        await expect(fetchThing()).resolves.toStrictEqual({ ok: true });
+
+        expect(bearers).toStrictEqual([`Bearer ${TEST_SESSION_ID}`]);
+    });
+});

--- a/src/helpers/flashlight/auth/proofOfWork.ts
+++ b/src/helpers/flashlight/auth/proofOfWork.ts
@@ -1,0 +1,94 @@
+// The only algorithm flashlight mints challenges for. Unknown values are
+// rejected rather than guessed at.
+export const POW_ALGORITHM = "sha256-leading-zeros-v1";
+
+// Mirrors flashlight's MaxDifficulty. A server bug must not wedge us in a hash
+// loop, so anything above this is an error rather than work.
+export const MAX_DIFFICULTY = 26;
+
+const MAX_ATTEMPTS = 2 ** MAX_DIFFICULTY * 8;
+
+// Every candidate costs an async crypto.subtle.digest, and awaiting them one at
+// a time caps us around 74k hashes/sec — difficulty 22 would then take ~56s
+// against a 60s challengeTTL measured from minting. Overlapping a window of
+// them is ~2.4x that, which keeps the whole usable difficulty band reachable.
+const BATCH_SIZE = 16;
+
+export interface Challenge {
+    readonly challenge: string;
+    readonly algorithm: string;
+    readonly difficulty: number;
+}
+
+const hasLeadingZeroBits = (digest: Uint8Array, bits: number): boolean => {
+    let remaining = bits;
+    for (const byte of digest) {
+        if (remaining <= 0) {
+            return true;
+        }
+        if (remaining < 8) {
+            // oxlint-disable-next-line eslint/no-bitwise
+            return byte >>> (8 - remaining) === 0;
+        }
+        if (byte !== 0) {
+            return false;
+        }
+        remaining -= 8;
+    }
+    return remaining <= 0;
+};
+
+/**
+ * Find a solution such that SHA-256(`challenge`:`solution`) has at least
+ * `difficulty` leading zero bits.
+ *
+ * Blocks the thread it runs on — call it from the worker unless workers are
+ * unavailable.
+ */
+export const solveChallenge = async ({
+    challenge,
+    algorithm,
+    difficulty,
+}: Challenge): Promise<string> => {
+    if (algorithm !== POW_ALGORITHM) {
+        throw new Error(`Unsupported proof-of-work algorithm: ${algorithm}`);
+    }
+    if (!Number.isInteger(difficulty) || difficulty < 0) {
+        throw new Error(`Invalid proof-of-work difficulty: ${difficulty.toString()}`);
+    }
+    if (difficulty > MAX_DIFFICULTY) {
+        throw new Error(
+            `Proof-of-work difficulty above the ceiling: ${difficulty.toString()} > ${MAX_DIFFICULTY.toString()}`,
+        );
+    }
+
+    const encoder = new TextEncoder();
+
+    for (let base = 0; base < MAX_ATTEMPTS; base += BATCH_SIZE) {
+        // Solutions are non-empty even at difficulty 0, where the empty string
+        // would be a valid proof. flashlight rejects an empty solution to keep
+        // clients from shipping a stub that never implements the hash loop.
+        // oxlint-disable-next-line eslint/no-await-in-loop
+        const digests = await Promise.all(
+            Array.from({ length: BATCH_SIZE }, async (_, offset) =>
+                crypto.subtle.digest(
+                    "SHA-256",
+                    encoder.encode(`${challenge}:${(base + offset).toString()}`),
+                ),
+            ),
+        );
+
+        const hit = digests.findIndex((digest) =>
+            hasLeadingZeroBits(new Uint8Array(digest), difficulty),
+        );
+        if (hit !== -1) {
+            // The lowest solution in the batch, so the result does not depend
+            // on BATCH_SIZE.
+            return (base + hit).toString();
+        }
+    }
+
+    throw new Error(
+        `Failed to solve proof-of-work challenge at difficulty ${difficulty.toString()}`,
+    );
+};

--- a/src/helpers/flashlight/auth/proofOfWork.unit.test.ts
+++ b/src/helpers/flashlight/auth/proofOfWork.unit.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "vitest";
+
+import { MAX_DIFFICULTY, POW_ALGORITHM, solveChallenge } from "./proofOfWork.ts";
+
+const digestBits = async (challenge: string, solution: string): Promise<number> => {
+    const digest = new Uint8Array(
+        await crypto.subtle.digest(
+            "SHA-256",
+            new TextEncoder().encode(`${challenge}:${solution}`),
+        ),
+    );
+
+    let bits = 0;
+    for (const byte of digest) {
+        if (byte === 0) {
+            bits += 8;
+            continue;
+        }
+        bits += Math.clz32(byte) - 24;
+        break;
+    }
+    return bits;
+};
+
+describe(solveChallenge, () => {
+    test("solves at difficulty 0 with a non-empty solution", async () => {
+        const solution = await solveChallenge({
+            challenge: "abc",
+            algorithm: POW_ALGORITHM,
+            difficulty: 0,
+        });
+
+        expect(solution.length).toBeGreaterThan(0);
+    });
+
+    test("solves at a non-zero difficulty", async () => {
+        const challenge = "some-challenge";
+        const difficulty = 12;
+
+        const solution = await solveChallenge({
+            challenge,
+            algorithm: POW_ALGORITHM,
+            difficulty,
+        });
+
+        await expect(digestBits(challenge, solution)).resolves.toBeGreaterThanOrEqual(
+            difficulty,
+        );
+    });
+
+    test("rejects an unknown algorithm", async () => {
+        await expect(
+            solveChallenge({
+                challenge: "abc",
+                algorithm: "sha256-leading-zeros-v2",
+                difficulty: 0,
+            }),
+        ).rejects.toThrow("Unsupported proof-of-work algorithm");
+    });
+
+    test("rejects a difficulty above the ceiling", async () => {
+        await expect(
+            solveChallenge({
+                challenge: "abc",
+                algorithm: POW_ALGORITHM,
+                difficulty: MAX_DIFFICULTY + 1,
+            }),
+        ).rejects.toThrow("above the ceiling");
+    });
+
+    test("rejects a nonsensical difficulty", async () => {
+        await expect(
+            solveChallenge({
+                challenge: "abc",
+                algorithm: POW_ALGORITHM,
+                difficulty: -1,
+            }),
+        ).rejects.toThrow("Invalid proof-of-work difficulty");
+    });
+});

--- a/src/helpers/flashlight/auth/proofOfWork.worker.ts
+++ b/src/helpers/flashlight/auth/proofOfWork.worker.ts
@@ -1,0 +1,30 @@
+import { solveChallenge } from "./proofOfWork.ts";
+import type { Challenge } from "./proofOfWork.ts";
+
+export type SolveResult =
+    | { readonly ok: true; readonly solution: string }
+    | { readonly ok: false; readonly error: string };
+
+// globalThis is typed as Window under the DOM lib, whose postMessage takes a
+// targetOrigin. In a worker it is the DedicatedWorkerGlobalScope, whose
+// postMessage does not.
+const post = (result: SolveResult): void => {
+    (globalThis as unknown as { postMessage: (message: SolveResult) => void })
+        // oxlint-disable-next-line unicorn/require-post-message-target-origin
+        .postMessage(result);
+};
+
+const handle = async (challenge: Challenge): Promise<void> => {
+    try {
+        post({ ok: true, solution: await solveChallenge(challenge) });
+    } catch (error: unknown) {
+        post({
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+        });
+    }
+};
+
+globalThis.addEventListener("message", (event: MessageEvent<Challenge>) => {
+    void handle(event.data);
+});

--- a/src/helpers/flashlight/auth/session.ts
+++ b/src/helpers/flashlight/auth/session.ts
@@ -1,0 +1,125 @@
+import { captureException } from "@sentry/react";
+
+import { getOrSetUserId } from "#helpers/userId.ts";
+
+import { anonymousLogin, refreshSession, requestChallenge } from "./api.ts";
+import { solve } from "./solve.ts";
+import { clearSession, readSession, writeSession } from "./storage.ts";
+import type { Session } from "./storage.ts";
+
+const AUTH_LOCK_NAME = "rainbow-auth";
+
+// Web Locks are released when the holder's callback settles or its tab dies. A
+// fetch that hangs is neither, and fetch has no default timeout, so without a
+// bound one wedged login blocks every other tab indefinitely.
+const AUTH_LOCK_TIMEOUT_MS = 10_000;
+
+const withAuthLock = async <T>(run: () => Promise<T>): Promise<T> => {
+    // Web Locks needs a secure context and Safari 15.4+. Without it the
+    // module-level promise below still dedupes within this document, and the
+    // worst case is one spare session.
+    const locks: LockManager | undefined = navigator.locks;
+    if (locks === undefined) {
+        return run();
+    }
+
+    let started = false;
+    const guarded = async () => {
+        started = true;
+        return run();
+    };
+
+    try {
+        return await locks.request(
+            AUTH_LOCK_NAME,
+            // AbortSignal.timeout is Safari 16+, so the lock is bounded on a
+            // best-effort basis rather than always.
+            { signal: AbortSignal.timeout(AUTH_LOCK_TIMEOUT_MS) },
+            guarded,
+        );
+    } catch (error: unknown) {
+        // An AbortError means "never acquired the lock" only if the callback
+        // never ran — a fetch aborted inside it throws the same name.
+        if (started) {
+            throw error;
+        }
+        // A spare session is strictly better than a tab that never loads.
+        return run();
+    }
+};
+
+// The anonymous handshake: challenge, solve, login. Keep this the only
+// tier-specific function — locking, refresh, retry and storage stay tier-blind.
+const acquireSession = async (): Promise<Session> => {
+    // Read the user id once: flashlight binds the challenge to it and compares
+    // it byte for byte at login.
+    const userId = getOrSetUserId();
+
+    const challenge = await requestChallenge(userId);
+    const solution = await solve(challenge);
+
+    return anonymousLogin({ userId, challenge: challenge.challenge, solution });
+};
+
+const acquire = async (observed: Session | null): Promise<Session> =>
+    withAuthLock(async () => {
+        const stored = readSession();
+
+        // Someone else already replaced the session we tried. Adopt theirs.
+        // Comparing ids, not presence: a loser that only checks presence goes
+        // on to refresh a token the winner already replaced.
+        if (stored !== null && stored.sessionId !== observed?.sessionId) {
+            return stored;
+        }
+
+        const refreshed = stored === null ? null : await refreshSession(stored);
+        if (stored !== null && refreshed === null) {
+            // A 401 from refresh means the session is finished by definition.
+            // Drop it now so a failing login doesn't leave later requests
+            // paying for a refresh that cannot succeed.
+            clearSession();
+        }
+
+        const next = refreshed ?? (await acquireSession());
+
+        writeSession(next);
+        return next;
+    });
+
+let inFlight: Promise<Session> | null = null;
+
+/**
+ * Get a usable session, refreshing or logging in as needed.
+ *
+ * `observed` is the session the caller held when it saw a 401 (or the refresh
+ * hint), or null if it held none.
+ */
+export const ensureSession = async (observed: Session | null): Promise<Session> => {
+    // Cleared in finally, rejections included: otherwise one failed login
+    // caches a rejected promise that every later caller adopts, and the tab
+    // never recovers. Backoff is react-query's job.
+    inFlight ??= (async () => {
+        try {
+            return await acquire(observed);
+        } finally {
+            inFlight = null;
+        }
+    })();
+    return inFlight;
+};
+
+/**
+ * Acquire a session in the background, at app boot.
+ *
+ * Overlaps the login round-trip with the app starting up; single-flight makes
+ * the first real query await this same promise.
+ */
+export const startSession = async (): Promise<void> => {
+    try {
+        await ensureSession(null);
+    } catch (error: unknown) {
+        captureException(error, {
+            extra: { message: "Failed to acquire a session at boot" },
+        });
+    }
+};

--- a/src/helpers/flashlight/auth/solve.ts
+++ b/src/helpers/flashlight/auth/solve.ts
@@ -1,0 +1,98 @@
+import { captureMessage } from "@sentry/react";
+
+import { solveChallenge } from "./proofOfWork.ts";
+import type { Challenge } from "./proofOfWork.ts";
+import type { SolveResult } from "./proofOfWork.worker.ts";
+
+/**
+ * The worker could not run at all — as opposed to running and reporting that it
+ * could not solve the challenge. Only the former is safe to retry inline.
+ */
+class WorkerFailedError extends Error {
+    public override name = "WorkerFailedError";
+}
+
+const createWorker = (): Worker | null => {
+    if (typeof Worker === "undefined") {
+        return null;
+    }
+    try {
+        // Vite resolves this exact pattern at build time — keep the "./" prefix
+        // oxlint-disable-next-line unicorn/relative-url-style
+        return new Worker(new URL("./proofOfWork.worker.ts", import.meta.url), {
+            type: "module",
+        });
+    } catch (error: unknown) {
+        captureMessage("Failed to create the proof-of-work worker", {
+            level: "warning",
+            extra: { error },
+        });
+        return null;
+    }
+};
+
+const awaitSolution = async (worker: Worker, challenge: Challenge): Promise<string> =>
+    // A worker only speaks in events, so this bridge has to be a new promise
+    // oxlint-disable-next-line promise/avoid-new
+    new Promise<string>((resolve, reject) => {
+        worker.addEventListener("message", (event: MessageEvent<SolveResult>) => {
+            const result = event.data;
+            if (result.ok) {
+                resolve(result.solution);
+            } else {
+                reject(new Error(result.error));
+            }
+        });
+        // ErrorEvent carries an `error: any`, which the rule cannot prove readonly
+        // oxlint-disable-next-line typescript/prefer-readonly-parameter-types
+        worker.addEventListener("error", (event: ErrorEvent) => {
+            // Cross-origin scripts scrub this to "Script error." with no filename
+            reject(
+                new WorkerFailedError(
+                    `The proof-of-work worker failed to run: ${event.message} (${event.filename}:${event.lineno}:${event.colno})`,
+                ),
+            );
+        });
+        // Without this listener a challenge that fails structured clone never settles
+        worker.addEventListener("messageerror", () => {
+            reject(
+                new WorkerFailedError(
+                    "The proof-of-work challenge did not reach the worker",
+                ),
+            );
+        });
+        // Worker.postMessage takes no targetOrigin
+        // oxlint-disable-next-line unicorn/require-post-message-target-origin
+        worker.postMessage(challenge);
+    });
+
+/**
+ * Solve a proof-of-work challenge off the hot path.
+ *
+ * Falls back to the main thread wherever the worker cannot run — unavailable,
+ * unconstructable, or failing to load — since the work is one hash at the
+ * current difficulty of 0. A worker that runs and reports that it could not
+ * solve the challenge is not retried: that verdict holds on any thread, and
+ * inline retries of a too-hard challenge would freeze the tab instead.
+ */
+export const solve = async (challenge: Challenge): Promise<string> => {
+    const worker = createWorker();
+    if (worker === null) {
+        return solveChallenge(challenge);
+    }
+
+    try {
+        return await awaitSolution(worker, challenge);
+    } catch (error: unknown) {
+        if (!(error instanceof WorkerFailedError)) {
+            throw error;
+        }
+        captureMessage("The proof-of-work worker failed — solving on the main thread", {
+            level: "warning",
+            extra: { error },
+        });
+        return await solveChallenge(challenge);
+    } finally {
+        worker.terminate();
+    }
+};

--- a/src/helpers/flashlight/auth/storage.ts
+++ b/src/helpers/flashlight/auth/storage.ts
@@ -1,0 +1,99 @@
+import { captureException } from "@sentry/react";
+
+const SESSION_LOCAL_STORAGE_KEY = "rainbow_auth_session";
+
+const SESSION_ID_PREFIX = "flsess_";
+
+const TIERS = ["anonymous", "microsoft"] as const;
+export type Tier = (typeof TIERS)[number];
+
+export interface Session {
+    readonly sessionId: string;
+    readonly tier: Tier;
+}
+
+// Only the session id and the tier are persisted. A monotonic deadline does not
+// survive a page load (performance.now() is per-document), and persisting an
+// absolute one would mean trusting the local wall clock. The version field
+// makes a future format change a discard rather than a parse crash.
+interface StoredSession {
+    readonly v: 1;
+    readonly sessionId: string;
+    readonly tier: Tier;
+}
+
+export const isTier = (value: unknown): value is Tier =>
+    typeof value === "string" && (TIERS as readonly string[]).includes(value);
+
+export const validateSessionId = (sessionId: unknown): sessionId is string =>
+    typeof sessionId === "string" && sessionId.startsWith(SESSION_ID_PREFIX);
+
+const parseSession = (raw: string): Session | null => {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        return null;
+    }
+
+    if (typeof parsed !== "object" || parsed === null) {
+        return null;
+    }
+    if (!("v" in parsed) || parsed.v !== 1) {
+        return null;
+    }
+    if (!("sessionId" in parsed) || !validateSessionId(parsed.sessionId)) {
+        return null;
+    }
+    if (!("tier" in parsed) || !isTier(parsed.tier)) {
+        return null;
+    }
+
+    return { sessionId: parsed.sessionId, tier: parsed.tier };
+};
+
+export const clearSession = (): void => {
+    try {
+        localStorage.removeItem(SESSION_LOCAL_STORAGE_KEY);
+    } catch (error: unknown) {
+        captureException(error, {
+            extra: { message: "Failed to clear the stored auth session" },
+        });
+    }
+};
+
+export const readSession = (): Session | null => {
+    let raw: string | null = null;
+    try {
+        raw = localStorage.getItem(SESSION_LOCAL_STORAGE_KEY);
+    } catch (error: unknown) {
+        captureException(error, {
+            extra: { message: "Failed to read the stored auth session" },
+        });
+        return null;
+    }
+    if (raw === null) {
+        return null;
+    }
+
+    const session = parseSession(raw);
+    if (session === null) {
+        clearSession();
+    }
+    return session;
+};
+
+export const writeSession = (session: Session): void => {
+    const stored: StoredSession = {
+        v: 1,
+        sessionId: session.sessionId,
+        tier: session.tier,
+    };
+    try {
+        localStorage.setItem(SESSION_LOCAL_STORAGE_KEY, JSON.stringify(stored));
+    } catch (error: unknown) {
+        captureException(error, {
+            extra: { message: "Failed to store the auth session" },
+        });
+    }
+};

--- a/src/helpers/flashlight/fetch.ts
+++ b/src/helpers/flashlight/fetch.ts
@@ -1,40 +1,41 @@
-import { captureException, captureMessage } from "@sentry/react";
+import { captureException } from "@sentry/react";
 
-import { env } from "#env.ts";
-import { getOrSetUserId } from "#helpers/userId.ts";
+import { ensureSession } from "./auth/session.ts";
+import { readSession } from "./auth/storage.ts";
+import type { Session } from "./auth/storage.ts";
+import { FlashlightResponseError, flashlightRequest } from "./request.ts";
+import type { FlashlightRequestOptions, FlashlightResult } from "./request.ts";
 
-// Client identification headers consumed by the flashlight backend. rainbow is
-// evergreen (always served from the latest deploy), so it always reports the
-// "evergreen" version. See https://github.com/Amund211/flashlight/pull/328.
-//
-// IMPORTANT: These headers identify us to flashlight and must ONLY be sent to
-// the flashlight API. Do not attach them to requests to any other server.
-const CLIENT_TYPE = "rainbow";
-const CLIENT_VERSION = "evergreen";
+type FlashlightFetchOptions = Omit<
+    FlashlightRequestOptions,
+    "bearer" | "expectedStatuses"
+>;
 
-// getFlashlightHeaders returns the headers to send with every request to the
-// flashlight API. Centralizing them here keeps the client identification
-// consistent across call sites and ensures they are only sent to flashlight.
-export const getFlashlightHeaders = (): Record<string, string> => ({
-    "X-User-Id": getOrSetUserId(),
-    "X-Client-Type": CLIENT_TYPE,
-    "X-Client-Version": CLIENT_VERSION,
-});
+const refreshInBackground = async (session: Session): Promise<void> => {
+    try {
+        await ensureSession(session);
+    } catch (error: unknown) {
+        captureException(error, {
+            extra: { message: "Failed to act on the session refresh hint" },
+        });
+    }
+};
 
-type SentryExtra = Readonly<Record<string, unknown>>;
-
-interface FlashlightFetchOptions {
-    // Passed straight to fetch. The wrapper merges its own headers in and
-    // forwards everything else untouched.
-    readonly init?: Readonly<RequestInit>;
-    // Prefix for the Sentry messages, e.g. "Failed to get history".
-    readonly errorContext: string;
-    // Call-site specific Sentry payload, attached to every report.
-    readonly extra: SentryExtra;
-}
+// The refresh hint goes through the same single-flight promise as a 401 does: a
+// six-query fan-out returns six copies of it, and each one must not become its
+// own refresh.
+const handleRefreshHint = <T>(result: FlashlightResult<T>, session: Session): T => {
+    if (result.refreshHint) {
+        void refreshInBackground(session);
+    }
+    return result.data;
+};
 
 /**
- * Fetch JSON from the flashlight API.
+ * Fetch JSON from the flashlight API, authenticated with the current session.
+ *
+ * Reactive-only: fire the request with whatever session is stored, and on a 401
+ * refresh (or log in again) and retry once.
  *
  * NOTE: The flashlight API does **not** allow third-party access.
  *       Do not send any requests to any endpoints without explicit permission.
@@ -44,60 +45,33 @@ export const flashlightFetch = async <T>(
     path: string,
     // RequestInit is not deeply readonly, and cannot be made so
     // oxlint-disable-next-line typescript/prefer-readonly-parameter-types
-    { init, errorContext, extra }: FlashlightFetchOptions,
+    options: FlashlightFetchOptions,
 ): Promise<T> => {
-    const headers = new Headers(init?.headers);
-    if (!headers.has("Content-Type")) {
-        headers.set("Content-Type", "application/json");
-    }
-    // Our headers always win: they identify the client to flashlight.
-    for (const [name, value] of Object.entries(getFlashlightHeaders())) {
-        headers.set(name, value);
-    }
-
-    const response = await fetch(`${env.VITE_FLASHLIGHT_URL}${path}`, {
-        ...init,
-        headers,
-    }).catch((error: unknown) => {
-        captureException(error, {
-            extra: { ...extra, message: `${errorContext}: failed to fetch` },
-        });
-        throw error;
-    });
-
-    const tags = { status: response.status, statusText: response.statusText };
-
-    // Read the body as text once, so both the error paths and the json parse
-    // work off the same (single) read.
-    const text = await response.text().catch((error: unknown) => {
-        captureException(error, {
-            tags,
-            extra: {
-                ...extra,
-                message: `${errorContext}: failed to read response text`,
-            },
-        });
-        throw error;
-    });
-
-    if (!response.ok) {
-        captureMessage(`${errorContext}: response error`, {
-            level: "error",
-            tags,
-            extra: { ...extra, ...tags, text },
-        });
-        throw new Error(
-            `${errorContext}. ${response.status.toString()} - ${response.statusText}: ${text}`,
-        );
-    }
+    const session = readSession() ?? (await ensureSession(null));
 
     try {
-        return JSON.parse(text) as T;
-    } catch (error: unknown) {
-        captureException(error, {
-            tags,
-            extra: { ...extra, message: `${errorContext}: failed to parse json`, text },
+        const result = await flashlightRequest<T>(path, {
+            ...options,
+            bearer: session.sessionId,
+            // A lapsed session is the reactive path working as designed, not a
+            // failure worth reporting.
+            expectedStatuses: [401],
         });
-        throw error;
+        return handleRefreshHint(result, session);
+    } catch (error: unknown) {
+        if (!(error instanceof FlashlightResponseError) || error.status !== 401) {
+            throw error;
+        }
+
+        // Re-sending the same init is only safe because every rainbow body is a
+        // string (never a consumed stream) and none of these endpoints mutate
+        // anything. An endpoint that streams a body, or one that writes, breaks
+        // this retry silently.
+        const next = await ensureSession(session);
+        const result = await flashlightRequest<T>(path, {
+            ...options,
+            bearer: next.sessionId,
+        });
+        return handleRefreshHint(result, next);
     }
 };

--- a/src/helpers/flashlight/request.ts
+++ b/src/helpers/flashlight/request.ts
@@ -1,0 +1,138 @@
+import { captureException, captureMessage } from "@sentry/react";
+
+import { env } from "#env.ts";
+import { getOrSetUserId } from "#helpers/userId.ts";
+
+// Client identification headers consumed by the flashlight backend. rainbow is
+// evergreen (always served from the latest deploy), so it always reports the
+// "evergreen" version. See https://github.com/Amund211/flashlight/pull/328.
+//
+// IMPORTANT: These headers identify us to flashlight and must ONLY be sent to
+// the flashlight API. Do not attach them to requests to any other server.
+const CLIENT_TYPE = "rainbow";
+const CLIENT_VERSION = "evergreen";
+
+// getFlashlightHeaders returns the headers to send with every request to the
+// flashlight API. Centralizing them here keeps the client identification
+// consistent across call sites and ensures they are only sent to flashlight.
+export const getFlashlightHeaders = (): Record<string, string> => ({
+    "X-User-Id": getOrSetUserId(),
+    "X-Client-Type": CLIENT_TYPE,
+    "X-Client-Version": CLIENT_VERSION,
+});
+
+// The server's "deal with your session now" hint, set on any response to a
+// request that carried a valid bearer, from 5 minutes before it expires.
+const REFRESH_HINT_HEADER = "X-Auth-Refresh";
+
+export class FlashlightResponseError extends Error {
+    public readonly status: number;
+
+    public constructor(message: string, status: number) {
+        super(message);
+        this.name = "FlashlightResponseError";
+        this.status = status;
+    }
+}
+
+type SentryExtra = Readonly<Record<string, unknown>>;
+
+export interface FlashlightRequestOptions {
+    // Passed straight to fetch. The wrapper merges its own headers in and
+    // forwards everything else untouched.
+    readonly init?: Readonly<RequestInit>;
+    // Prefix for the Sentry messages, e.g. "Failed to get history".
+    readonly errorContext: string;
+    // Call-site specific Sentry payload, attached to every report.
+    readonly extra: SentryExtra;
+    // Session id to send as a bearer, if any.
+    readonly bearer?: string | undefined;
+    // Statuses that are part of the protocol rather than a failure. Still
+    // thrown, but not reported to Sentry.
+    readonly expectedStatuses?: readonly number[];
+}
+
+export interface FlashlightResult<T> {
+    readonly data: T;
+    // Whether the response carried the refresh hint header.
+    readonly refreshHint: boolean;
+}
+
+/**
+ * Fetch JSON from the flashlight API, without any session handling.
+ *
+ * Callers outside of the auth endpoints want `flashlightFetch`, which adds the
+ * bearer and the reactive re-auth on top of this.
+ *
+ * NOTE: The flashlight API does **not** allow third-party access.
+ *       Do not send any requests to any endpoints without explicit permission.
+ *       Reach out on Discord for more information. https://discord.gg/k4FGUnEHYg
+ */
+export const flashlightRequest = async <T>(
+    path: string,
+    // RequestInit is not deeply readonly, and cannot be made so
+    // oxlint-disable-next-line typescript/prefer-readonly-parameter-types
+    { init, errorContext, extra, bearer, expectedStatuses }: FlashlightRequestOptions,
+): Promise<FlashlightResult<T>> => {
+    const headers = new Headers(init?.headers);
+    if (!headers.has("Content-Type")) {
+        headers.set("Content-Type", "application/json");
+    }
+    // Our headers always win: they identify the client to flashlight.
+    for (const [name, value] of Object.entries(getFlashlightHeaders())) {
+        headers.set(name, value);
+    }
+    if (bearer !== undefined) {
+        headers.set("Authorization", `Bearer ${bearer}`);
+    }
+
+    const response = await fetch(`${env.VITE_FLASHLIGHT_URL}${path}`, {
+        ...init,
+        headers,
+    }).catch((error: unknown) => {
+        captureException(error, {
+            extra: { ...extra, message: `${errorContext}: failed to fetch` },
+        });
+        throw error;
+    });
+
+    const tags = { status: response.status, statusText: response.statusText };
+    const refreshHint = response.headers.get(REFRESH_HINT_HEADER) === "1";
+
+    // Read the body as text once, so both the error paths and the json parse
+    // work off the same (single) read.
+    const text = await response.text().catch((error: unknown) => {
+        captureException(error, {
+            tags,
+            extra: {
+                ...extra,
+                message: `${errorContext}: failed to read response text`,
+            },
+        });
+        throw error;
+    });
+
+    if (!response.ok) {
+        if (expectedStatuses?.includes(response.status) !== true) {
+            captureMessage(`${errorContext}: response error`, {
+                level: "error",
+                tags,
+                extra: { ...extra, ...tags, text },
+            });
+        }
+        throw new FlashlightResponseError(
+            `${errorContext}. ${response.status.toString()} - ${response.statusText}: ${text}`,
+            response.status,
+        );
+    }
+
+    try {
+        return { data: JSON.parse(text) as T, refreshHint };
+    } catch (error: unknown) {
+        captureException(error, {
+            tags,
+            extra: { ...extra, message: `${errorContext}: failed to parse json`, text },
+        });
+        throw error;
+    }
+};

--- a/src/helpers/flashlight/request.unit.test.ts
+++ b/src/helpers/flashlight/request.unit.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe, vi, afterEach } from "vitest";
 
-import { flashlightFetch, getFlashlightHeaders } from "./fetch.ts";
+import { flashlightRequest, getFlashlightHeaders } from "./request.ts";
 
 describe(getFlashlightHeaders, () => {
     test("identifies rainbow as the client", () => {
@@ -25,7 +25,7 @@ const mockFetch = (response: Response) => {
     return fetchMock;
 };
 
-describe(flashlightFetch, () => {
+describe(flashlightRequest, () => {
     afterEach(() => {
         vi.unstubAllGlobals();
     });
@@ -33,7 +33,7 @@ describe(flashlightFetch, () => {
     test("parses the response and sends the client headers", async () => {
         const fetchMock = mockFetch(Response.json({ hello: "world" }));
 
-        const data = await flashlightFetch<{ hello: string }>("/v1/thing", {
+        const { data } = await flashlightRequest<{ hello: string }>("/v1/thing", {
             errorContext: "Failed to get thing",
             extra: {},
         });
@@ -50,7 +50,7 @@ describe(flashlightFetch, () => {
     test("forwards init to fetch", async () => {
         const fetchMock = mockFetch(Response.json([]));
 
-        await flashlightFetch("/v1/thing", {
+        await flashlightRequest("/v1/thing", {
             init: { method: "POST", body: JSON.stringify({ a: 1 }) },
             errorContext: "Failed to get thing",
             extra: {},
@@ -65,7 +65,7 @@ describe(flashlightFetch, () => {
         mockFetch(new Response("nope", { status: 500 }));
 
         await expect(
-            flashlightFetch("/v1/thing", {
+            flashlightRequest("/v1/thing", {
                 errorContext: "Failed to get thing",
                 extra: {},
             }),
@@ -76,10 +76,50 @@ describe(flashlightFetch, () => {
         mockFetch(new Response("not json"));
 
         await expect(
-            flashlightFetch("/v1/thing", {
+            flashlightRequest("/v1/thing", {
                 errorContext: "Failed to get thing",
                 extra: {},
             }),
         ).rejects.toThrow("JSON");
+    });
+
+    test("sends the bearer when given one", async () => {
+        const fetchMock = mockFetch(Response.json({}));
+
+        await flashlightRequest("/v1/thing", {
+            errorContext: "Failed to get thing",
+            extra: {},
+            bearer: "flsess_token",
+        });
+
+        const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+        expect(new Headers(init.headers).get("Authorization")).toBe(
+            "Bearer flsess_token",
+        );
+    });
+
+    test("reports the status on a non-ok response", async () => {
+        mockFetch(new Response("nope", { status: 401 }));
+
+        await expect(
+            flashlightRequest("/v1/thing", {
+                errorContext: "Failed to get thing",
+                extra: {},
+            }),
+        ).rejects.toMatchObject({
+            name: "FlashlightResponseError",
+            status: 401,
+        });
+    });
+
+    test("reads the refresh hint", async () => {
+        mockFetch(Response.json({}, { headers: { "X-Auth-Refresh": "1" } }));
+
+        const { refreshHint } = await flashlightRequest("/v1/thing", {
+            errorContext: "Failed to get thing",
+            extra: {},
+        });
+
+        expect(refreshHint).toBe(true);
     });
 });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,9 +10,13 @@ import "@fontsource/roboto/300.css";
 import "@fontsource/roboto/400.css";
 import "@fontsource/roboto/500.css";
 import "@fontsource/roboto/700.css";
+import { startSession } from "#helpers/flashlight/auth/session.ts";
 import { getOrSetUserId } from "#helpers/userId.ts";
 
 const userId = getOrSetUserId(); // Ensure a user ID is set
+
+// Overlap the login round-trip with app boot
+void startSession();
 
 // Set the user in Sentry
 setUser({

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -1,6 +1,33 @@
+import type {
+    APIChallengeResponse,
+    APISessionResponse,
+} from "#helpers/flashlight/auth/api.ts";
+import { POW_ALGORITHM } from "#helpers/flashlight/auth/proofOfWork.ts";
 import { isNormalizedUUID } from "#helpers/uuid.ts";
 import type { APIPlayerDataPIT } from "#queries/playerdata.ts";
 import type { APISession } from "#queries/sessions.ts";
+
+export const TEST_SESSION_ID = "flsess_test_session";
+
+export const makeChallengeResponse = (userId: string): APIChallengeResponse => ({
+    challenge: `challenge-for-${userId}`,
+    algorithm: POW_ALGORITHM,
+    // Difficulty 0 so the suite never burns CPU on the hash loop. A non-zero
+    // difficulty is covered directly against the solver.
+    difficulty: 0,
+    expiresInSeconds: 60,
+});
+
+export const makeSessionResponse = (
+    sessionId: string = TEST_SESSION_ID,
+): APISessionResponse => ({
+    sessionId,
+    tier: "anonymous",
+    expiresInSeconds: 3600,
+    refreshUntilInSeconds: 7200,
+    refreshInSeconds: 3300,
+    canRefresh: true,
+});
 
 interface User {
     username: string;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -11,8 +11,10 @@ import type { APIWrappedData } from "#queries/wrapped.ts";
 import {
     findUserByUsername,
     findUserByUUID,
+    makeChallengeResponse,
     makePlayerDataPIT,
     makeSession,
+    makeSessionResponse,
     makeWrappedResponse,
 } from "./data.ts";
 
@@ -36,6 +38,43 @@ const validateUUID = (uuid: unknown): string => {
 };
 
 export const handlers = [
+    http.post(
+        flashlightEndpoint("v1/auth/anonymous/challenge"),
+        async ({ request }) => {
+            const body = (await request.json()) as { userId: string };
+            if (typeof body.userId !== "string" || body.userId.length === 0) {
+                throw new TypeError("Invalid userId");
+            }
+
+            return HttpResponse.json(makeChallengeResponse(body.userId));
+        },
+    ),
+    http.post(flashlightEndpoint("v1/auth/anonymous/login"), async ({ request }) => {
+        const body = (await request.json()) as {
+            userId: string;
+            challenge: string;
+            solution: string;
+        };
+        if (body.challenge !== makeChallengeResponse(body.userId).challenge) {
+            throw new Error("Challenge was not minted for this userId");
+        }
+        // flashlight rejects an empty solution even at difficulty 0.
+        if (typeof body.solution !== "string" || body.solution.length === 0) {
+            throw new Error("Missing solution");
+        }
+
+        return HttpResponse.json(makeSessionResponse());
+    }),
+    http.post(flashlightEndpoint("v1/auth/refresh"), ({ request }) => {
+        const authorization = request.headers.get("Authorization");
+        if (authorization?.startsWith("Bearer flsess_") !== true) {
+            return new HttpResponse(null, { status: 401 });
+        }
+
+        return HttpResponse.json(
+            makeSessionResponse(authorization.slice("Bearer ".length)),
+        );
+    }),
     http.get(flashlightEndpoint("v1/account/uuid/:uuid"), (req) => {
         const uuid = validateUUID(req.params.uuid);
 

--- a/src/test/msw-test.ts
+++ b/src/test/msw-test.ts
@@ -1,8 +1,9 @@
+import type { SetupWorker } from "msw/browser";
 import { test as testBase } from "vitest";
 
 import { worker } from "#mocks/worker.ts";
 
-export const mswTest = testBase.extend({
+export const mswTest = testBase.extend<{ worker: SetupWorker }>({
     worker: [
         // oxlint-disable-next-line no-empty-pattern
         async ({}, use) => {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,8 @@
 import { beforeEach } from "vitest";
 
 beforeEach(() => {
-    // Ensure localstorage doesn't leak between tests
+    // Ensure localstorage doesn't leak between tests. NOTE: this drops the auth
+    // session too, so every test does a (mocked) anonymous login before its
+    // first query.
     localStorage.clear();
 });


### PR DESCRIPTION
Implements the rainbow side of the anonymous tier from the auth plan. **Stacked on #342** — review that first; this PR's diff includes it until it merges.

Rainbow acquires a flashlight session and sends it as `Authorization: Bearer flsess_…` on every API request, so the per-user rate budget keys on a server-verified identity rather than a self-asserted header. `X-User-Id` keeps going out alongside it indefinitely — `RegisterUserVisit`, the blocklist and the metric attributes all key off it.

## The flow

Everything lives behind `flashlightFetch`, so the six query modules are untouched.

- **Reactive-only.** Fire the request with whatever session is stored; on a 401 refresh and retry once; if the refresh 401s, log in from scratch and retry. A **429 from refresh is not a failed refresh** — the session is untouched, so it is reused rather than replaced. No proactive timer. A 401 from refresh means the session is finished by definition, so it is cleared before login is attempted — otherwise a failing login leaves later requests paying for a refresh that cannot succeed.
- **Proof-of-work login.** `challenge → solve → login`, with the solve in a Web Worker. Difficulty is 0 today but is a server-side dial, so the ceiling (26) is honoured and unknown `algorithm` values are rejected rather than guessed at. The same `userId` is read once and sent to both calls — flashlight binds the challenge to it and compares byte for byte.

  The solver hashes 16 candidates at a time. Awaiting `crypto.subtle.digest` one at a time measures ~74k hashes/sec, which puts difficulty 22 at ~56s against a 60s `challengeTTL` counted from *minting* — i.e. the top of the plan's usable band would be unreachable. Overlapping a batch is ~2.4× that. It still returns the lowest solution in the batch, so the result does not depend on `BATCH_SIZE`.
- **Single-flight, two layers.** A module-level promise dedupes callers inside this document; a Web Lock dedupes across tabs. Inside the lock, storage is re-read and **session ids compared** (not just presence) so a loser adopts the winner's session instead of minting a spare. The lock is feature-detected and time-bounded — without it, layer one still holds and the worst case is one spare session.
- **`X-Auth-Refresh`.** The hint feeds the *same* single-flight promise as a 401, so a six-query fan-out does one refresh, not six. (Server side is on flashlight's unmerged `auth-refresh-min-interval` branch; ignoring the header stays correct, so this is safe to ship first.)
- **Storage** is `{ v: 1, sessionId, tier }` under one key, validated on read like `validateUserId` — anything that doesn't look like a `flsess_` token is discarded as "no session". Nothing time-based is persisted: `performance.now()` doesn't survive a page load and an absolute deadline would mean trusting the wall clock. `canRefresh` is not stored — it only earns its keep next to a proactive timer.

`flashlight/request.ts` is split out of `flashlight/fetch.ts` (auth-free, returns the parsed body plus the refresh hint, throws a `FlashlightResponseError` carrying the status) so the auth endpoints can call it without an import cycle back through the session logic. That split is not stylistic: `import/no-cycle` is enabled here and errors on exactly the `fetch.ts → auth/session.ts → auth/api.ts → fetch.ts` loop.

`acquireSession()` is the only tier-specific function; lock, refresh, retry and storage are tier-blind, and `tier` is stored so a failed refresh knows which path to take. No `/auth/callback` route is added — that path stays unclaimed on purpose.

## Consequences to be aware of

**Auth is a hard dependency.** Once rainbow sends a bearer, a token-handling bug is not degraded service: every rainbow request 401s, and a broken login endpoint means the app cannot fetch anything. Falling back to an unauthenticated request would have been free (flashlight still accepts requests with no `Authorization`) and was deliberately not done — a quiet fallback is a worse failure than a loud one. Per the plan's rollout order, staging against `flashlight-test` is the whole safety net.

**The refresh hint and the 429 throttle ship dormant.** Both live on flashlight's unmerged `auth-refresh-min-interval` branch, so against deployed flashlight neither path runs. Rainbow goes out first regardless; the hint (and whether `Access-Control-Expose-Headers` actually makes it readable, which is only observable in a real deploy) gets verified whenever that branch merges.

## Testing

- `test:unit` (926) and `test:ui` chromium (215) pass; `vite:build` emits the worker as its own chunk. WebKit could not run locally (missing system libs) — CI covers it.
- New browser tests cover login-when-empty, 401 → refresh → retry, 401 → refresh-401 → login → retry, the throttle case (401 → refresh-429 → retry with the stored token, **no login**), the dead-session clear when login then fails, single-flight across a concurrent fan-out, and a corrupted stored token.
- New unit tests cover the solver at difficulty 0 and at 12, plus the algorithm and difficulty-ceiling refusals.
- msw challenge/login/refresh handlers are mandatory, not optional: `onUnhandledRequest: "error"` plus a `localStorage` clear before every test means every UI test now does a fresh login before its first query. The challenge mock returns difficulty 0 so the suite never burns CPU.

The cross-tab lock path is not reachable from CI (neither project can open a second document) and needs verifying by hand on staging.

## Notes

- No `storage` event listener: `localStorage` is read fresh on every request, so an idle tab picks up another tab's new token without one.
- `prefer-readonly-parameter-types` gained `MessageEvent`, `Worker` and `Uint8Array` in its lib allow-list — none can be expressed as deeply readonly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
