### PR TITLE
feat(session-detail): break multi-game gap tiles down by gamemode

### DIFF
--- a/src/helpers/sessionDetail.ts
+++ b/src/helpers/sessionDetail.ts
@@ -1,5 +1,5 @@
 import type { History } from "#queries/history.ts";
-import type { StatsPIT } from "#queries/playerdata.ts";
+import type { PlayerDataPIT, StatsPIT } from "#queries/playerdata.ts";
 import type {
     GameOutcome,
     GameResult,
@@ -212,21 +212,79 @@ const toModeStats = (de: StatDelta): ModeStats => ({
 // modes) that the wire contract folds into `overall` but doesn't break out.
 export type ModeBreakdownKey = Gamemode | "other";
 
-export const modeBreakdown = (
-    session: Session,
-): Record<ModeBreakdownKey, ModeStats> => {
+/**
+ * A pair of point-in-time snapshots to diff. Both a whole `Session` and a
+ * single `GameSegment` satisfy this, so the same per-mode breakdown serves the
+ * "By gamemode" panel and one multi-game gap in the momentum strip.
+ */
+interface Span {
+    readonly start: PlayerDataPIT;
+    readonly end: PlayerDataPIT;
+}
+
+export const modeBreakdown = (span: Span): Record<ModeBreakdownKey, ModeStats> => {
     const out = {} as Record<ModeBreakdownKey, ModeStats>;
     let core = ZERO_DELTA;
     for (const mode of GAMEMODES) {
-        const delta = statDelta(session.start[mode], session.end[mode]);
+        const delta = statDelta(span.start[mode], span.end[mode]);
         out[mode] = toModeStats(delta);
         core = addDelta(core, delta);
     }
     // Some players have strange stats where sum(gamemodes) != overall
     // surface that here in case it happens.
-    const overall = statDelta(session.start.overall, session.end.overall);
+    const overall = statDelta(span.start.overall, span.end.overall);
     out.other = toModeStats(subtractDelta(overall, core));
     return out;
+};
+
+export interface ModeEntry {
+    readonly key: ModeBreakdownKey;
+    readonly stats: ModeStats;
+}
+
+/**
+ * The modes actually played across a span, in the canonical display order with
+ * the "other" bucket last. Presence is strictly "gamesPlayed advanced", so the
+ * entries always account for exactly the games the span covers — a mode whose
+ * game counter didn't move is left out even if its other counters did.
+ */
+export const playedModes = (span: Span): ModeEntry[] => {
+    const data = modeBreakdown(span);
+    const entries: ModeEntry[] = GAMEMODES.filter((mode) => data[mode].games > 0).map(
+        (mode) => ({ key: mode, stats: data[mode] }),
+    );
+    if (data.other.games > 0) {
+        entries.push({ key: "other", stats: data.other });
+    }
+    return entries;
+};
+
+/**
+ * How a multi-game segment's games split by outcome, as shares of 1. Anything
+ * neither won nor lost — draws, or counters that don't reconcile — lands in
+ * `unknownShare` rather than being silently dropped. Null when the span covers
+ * no games at all, which has no split to draw.
+ */
+export interface OutcomeSplit {
+    readonly winShare: number;
+    readonly lossShare: number;
+    readonly unknownShare: number;
+}
+
+export const outcomeSplit = (span: Span): OutcomeSplit | null => {
+    const delta = statDelta(span.start.overall, span.end.overall);
+    // Clamp before dividing: a counter that moved backwards would otherwise
+    // produce a negative share and flip the bar inside out. Sizing the bar by
+    // max(games, wins + losses) keeps it full when the record over-accounts.
+    const wins = Math.max(0, delta.wins);
+    const losses = Math.max(0, delta.losses);
+    const total = Math.max(delta.games, wins + losses);
+    if (total <= 0) return null;
+    return {
+        winShare: wins / total,
+        lossShare: losses / total,
+        unknownShare: (total - wins - losses) / total,
+    };
 };
 
 /**

--- a/src/helpers/sessionDetail.unit.test.ts
+++ b/src/helpers/sessionDetail.unit.test.ts
@@ -23,6 +23,8 @@ import {
     inferredGameCount,
     isPerfectGame,
     modeBreakdown,
+    outcomeSplit,
+    playedModes,
     segmentGameNumbers,
     sessionTagKeys,
     trailingStreak,
@@ -1151,5 +1153,103 @@ describe(gameAccolade, () => {
 
     test.each(cases)("$name", ({ game, expected }) => {
         expect(gameAccolade(makeGame(game))).toBe(expected);
+    });
+});
+
+describe(playedModes, () => {
+    test("lists the modes played in canonical order with 'other' last", () => {
+        const end = makePIT({
+            // Three games: one solo win, one fours loss, and one in a mode the
+            // wire contract only reflects in `overall`.
+            overall: makeStats({ gamesPlayed: 3, wins: 1, losses: 1, finalKills: 5 }),
+            solo: makeStats({ gamesPlayed: 1, wins: 1, finalKills: 3 }),
+            fours: makeStats({ gamesPlayed: 1, losses: 1, finalKills: 1 }),
+        });
+
+        const modes = playedModes({ start: PLACEHOLDER_PIT, end });
+
+        expect(modes.map((mode) => mode.key)).toStrictEqual(["solo", "fours", "other"]);
+        expect(modes.map((mode) => mode.stats.games)).toStrictEqual([1, 1, 1]);
+        // The "other" bucket carries the finals the core modes don't claim.
+        expect(modes[2].stats.fk).toBe(1);
+    });
+
+    test("omits a mode whose stats moved without its game counter", () => {
+        const end = makePIT({
+            overall: makeStats({ gamesPlayed: 1, wins: 1 }),
+            threes: makeStats({ finalKills: 2 }),
+        });
+
+        expect(
+            playedModes({ start: PLACEHOLDER_PIT, end }).map((mode) => mode.key),
+        ).toStrictEqual(["other"]);
+    });
+
+    test("omits 'other' when the core modes account for every game", () => {
+        const end = makePIT({
+            overall: makeStats({ gamesPlayed: 2, wins: 2 }),
+            doubles: makeStats({ gamesPlayed: 2, wins: 2 }),
+        });
+
+        expect(
+            playedModes({ start: PLACEHOLDER_PIT, end }).map((mode) => mode.key),
+        ).toStrictEqual(["doubles"]);
+    });
+
+    test("omits 'other' when the core modes over-account for the games", () => {
+        const end = makePIT({
+            // Stats that don't reconcile: solo claims more games than overall.
+            overall: makeStats({ gamesPlayed: 1, wins: 1 }),
+            solo: makeStats({ gamesPlayed: 2, wins: 1 }),
+        });
+
+        expect(
+            playedModes({ start: PLACEHOLDER_PIT, end }).map((mode) => mode.key),
+        ).toStrictEqual(["solo"]);
+    });
+});
+
+describe(outcomeSplit, () => {
+    const cases: {
+        name: string;
+        overall: Partial<StatsPIT>;
+        expected: { winShare: number; unknownShare: number; lossShare: number } | null;
+    }[] = [
+        {
+            name: "all wins fills the bar green",
+            overall: { gamesPlayed: 3, wins: 3 },
+            expected: { winShare: 1, unknownShare: 0, lossShare: 0 },
+        },
+        {
+            name: "one win and one loss splits it in half",
+            overall: { gamesPlayed: 2, wins: 1, losses: 1 },
+            expected: { winShare: 0.5, unknownShare: 0, lossShare: 0.5 },
+        },
+        {
+            name: "a game that is neither won nor lost becomes a neutral slice",
+            overall: { gamesPlayed: 4, wins: 2, losses: 1 },
+            expected: { winShare: 0.5, unknownShare: 0.25, lossShare: 0.25 },
+        },
+        {
+            name: "a record that over-accounts sizes the bar by wins + losses",
+            overall: { gamesPlayed: 1, wins: 1, losses: 1 },
+            expected: { winShare: 0.5, unknownShare: 0, lossShare: 0.5 },
+        },
+        {
+            name: "counters moving backwards never produce a negative slice",
+            overall: { gamesPlayed: 2, wins: -1, losses: 1 },
+            expected: { winShare: 0, unknownShare: 0.5, lossShare: 0.5 },
+        },
+        {
+            name: "a window covering no games has no split",
+            overall: {},
+            expected: null,
+        },
+    ];
+
+    test.each(cases)("$name", ({ overall, expected }) => {
+        const end = makePIT({ overall: makeStats(overall) });
+
+        expect(outcomeSplit({ start: PLACEHOLDER_PIT, end })).toStrictEqual(expected);
     });
 });

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -125,6 +125,74 @@ export const makePlayerDataPIT = (
     overall: makeStatsPIT(multiplier * 5),
 });
 
+type APIStatsPIT = APIPlayerDataPIT["overall"];
+
+// The counters a mocked stretch of games advances. Every field is required so a
+// new stat can't be silently left flat when the wire contract grows one.
+type StatsDelta = Omit<APIStatsPIT, "winstreak">;
+
+const addStats = (base: APIStatsPIT, delta: StatsDelta): APIStatsPIT => ({
+    winstreak: base.winstreak,
+    gamesPlayed: base.gamesPlayed + delta.gamesPlayed,
+    wins: base.wins + delta.wins,
+    losses: base.losses + delta.losses,
+    bedsBroken: base.bedsBroken + delta.bedsBroken,
+    bedsLost: base.bedsLost + delta.bedsLost,
+    finalKills: base.finalKills + delta.finalKills,
+    finalDeaths: base.finalDeaths + delta.finalDeaths,
+    kills: base.kills + delta.kills,
+    deaths: base.deaths + delta.deaths,
+});
+
+/**
+ * A snapshot advanced past `base` by three games that can't be attributed
+ * individually: one solo win, one fours loss, and one played in a mode the wire
+ * contract folds into `overall` without breaking out — so `overall` gains three
+ * games while the core modes only account for two. Drives the multi-game gap
+ * tile on the session detail page.
+ */
+export const makeMultiGamePlayerDataPIT = (
+    base: APIPlayerDataPIT,
+    queriedAt: string,
+): APIPlayerDataPIT => ({
+    ...base,
+    queriedAt,
+    experience: base.experience + 1240,
+    solo: addStats(base.solo, {
+        gamesPlayed: 1,
+        wins: 1,
+        losses: 0,
+        bedsBroken: 2,
+        bedsLost: 0,
+        finalKills: 3,
+        finalDeaths: 1,
+        kills: 5,
+        deaths: 2,
+    }),
+    fours: addStats(base.fours, {
+        gamesPlayed: 1,
+        wins: 0,
+        losses: 1,
+        bedsBroken: 0,
+        bedsLost: 1,
+        finalKills: 1,
+        finalDeaths: 1,
+        kills: 3,
+        deaths: 4,
+    }),
+    overall: addStats(base.overall, {
+        gamesPlayed: 3,
+        wins: 1,
+        losses: 1,
+        bedsBroken: 3,
+        bedsLost: 1,
+        finalKills: 5,
+        finalDeaths: 2,
+        kills: 10,
+        deaths: 7,
+    }),
+});
+
 export const makeSession = (
     uuid: string,
     startTime: string,

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -12,6 +12,7 @@ import {
     findUserByUsername,
     findUserByUUID,
     makeChallengeResponse,
+    makeMultiGamePlayerDataPIT,
     makePlayerDataPIT,
     makeSession,
     makeSessionResponse,
@@ -160,12 +161,16 @@ export const handlers = [
         const startDate = new Date(timeDate.getTime() - 60 * 60 * 1000);
         const midDate = new Date(timeDate);
         const mid2Date = new Date(timeDate.getTime() + 30 * 60 * 1000);
+        const mid3Date = new Date(timeDate.getTime() + 45 * 60 * 1000);
         const endDate = new Date(timeDate.getTime() + 60 * 60 * 1000);
 
         const startPIT = makePlayerDataPIT(body.uuid, startDate.toISOString(), 1);
         const midPIT = makePlayerDataPIT(body.uuid, midDate.toISOString(), 2);
         const mid2PIT = makePlayerDataPIT(body.uuid, mid2Date.toISOString(), 3);
-        const endPIT = makePlayerDataPIT(body.uuid, endDate.toISOString(), 4);
+        const mid3PIT = makePlayerDataPIT(body.uuid, mid3Date.toISOString(), 4);
+        // Last segment covers several games at once, so its counters advance
+        // from the previous snapshot rather than jumping a whole multiplier.
+        const endPIT = makeMultiGamePlayerDataPIT(mid3PIT, endDate.toISOString());
 
         const response: APISessionAtResponse = {
             session: makeSession(
@@ -206,7 +211,7 @@ export const handlers = [
                 },
                 {
                     start: mid2PIT,
-                    end: endPIT,
+                    end: mid3PIT,
                     game: {
                         gamemode: "4v4",
                         outcome: "win",
@@ -219,6 +224,7 @@ export const handlers = [
                         experience: 1800,
                     },
                 },
+                { start: mid3PIT, end: endPIT, game: null },
             ],
         };
 

--- a/src/routes/session/$uuid_.detail.tsx
+++ b/src/routes/session/$uuid_.detail.tsx
@@ -63,7 +63,9 @@ import type {
     GameAccoladeKind,
     Milestone,
     ModeBreakdownKey,
+    ModeEntry,
     ModeStats,
+    OutcomeSplit,
     SegmentGameNumber,
     SessionAggregate,
     SessionTagKey,
@@ -80,11 +82,12 @@ import {
     gameNumberLabel,
     inferredGameCount,
     modeBreakdown,
+    outcomeSplit,
+    playedModes,
     segmentDurationMs,
     segmentExperience,
     segmentGameNumbers,
     sessionTagKeys,
-    statDelta,
     trailingStreak,
 } from "#helpers/sessionDetail.ts";
 import { normalizeUUID } from "#helpers/uuid.ts";
@@ -252,6 +255,50 @@ const outcomeColor = (
         }
     }
 };
+
+// Identity colour and label for a breakdown key — the five real modes carry
+// their palette accent, the catch-all "other" bucket stays muted.
+const modeColor = (
+    // oxlint-disable-next-line typescript/prefer-readonly-parameter-types
+    theme: Theme,
+    key: ModeBreakdownKey,
+): string => (key === "other" ? theme.palette.textMuted : theme.palette.gamemode[key]);
+
+const modeLabel = (key: ModeBreakdownKey): string =>
+    key === "other" ? "Other" : getGamemodeLabel(key, true);
+
+// The identity dot a gamemode is recognised by across the page: on a game tile,
+// in the expanded detail header and beside each breakdown row.
+const ModeDot: React.FC<{ modeKey: ModeBreakdownKey }> = ({ modeKey }) => {
+    const theme = useTheme();
+    return (
+        <Box
+            sx={{
+                width: 7,
+                height: 7,
+                borderRadius: "50%",
+                bgcolor: modeColor(theme, modeKey),
+                flexShrink: 0,
+            }}
+        />
+    );
+};
+
+// One dot per mode played in a segment, in canonical order. Unlabelled by
+// design — the tile has no room — so the modes are named for screen readers
+// and spelled out in the expanded breakdown below the strip.
+const ModeDots: React.FC<{ modes: readonly ModeEntry[] }> = ({ modes }) =>
+    modes.length === 0 ? null : (
+        <Stack
+            direction="row"
+            aria-label={`Modes played: ${modes.map((mode) => modeLabel(mode.key)).join(", ")}`}
+            sx={{ alignItems: "center", gap: 0.5 }}
+        >
+            {modes.map((mode) => (
+                <ModeDot key={mode.key} modeKey={mode.key} />
+            ))}
+        </Stack>
+    );
 
 const Panel: React.FC<{ children: React.ReactNode; sx?: object }> = ({
     children,
@@ -707,6 +754,92 @@ const StatusPill: React.FC<{
     return tooltip === undefined ? pill : <Tooltip title={tooltip}>{pill}</Tooltip>;
 };
 
+// One uppercase-label / monospace-value cell of a stat grid.
+const StatCell: React.FC<{ label: string; value: string; fontSize?: number }> = ({
+    label,
+    value,
+    fontSize = 16,
+}) => (
+    <Box>
+        <Typography
+            variant="caption"
+            color="textSecondary"
+            sx={{
+                textTransform: "uppercase",
+                letterSpacing: 0.6,
+                fontSize: 10,
+            }}
+        >
+            {label}
+        </Typography>
+        <Typography sx={{ fontFamily: "monospace", fontSize, mt: 0.5 }}>
+            {value}
+        </Typography>
+    </Box>
+);
+
+const STAT_GRID_SX = {
+    display: "grid",
+    gridTemplateColumns: "repeat(4, 1fr)",
+    gap: 1,
+} as const;
+
+// Per-gamemode stats for a stretch of games that couldn't be attributed one by
+// one. Only the modes actually played get a row. XP is deliberately absent:
+// experience is only known for the whole segment, so it stays in the header
+// instead of being split across modes it can't be attributed to.
+const ModeRows: React.FC<{ modes: readonly ModeEntry[] }> = ({ modes }) => (
+    <Stack sx={{ gap: 2, maxWidth: 720, mx: "auto" }}>
+        {modes.map(({ key, stats }) => (
+            <Box key={key}>
+                <Stack
+                    direction="row"
+                    sx={{
+                        alignItems: "center",
+                        gap: 0.75,
+                        mb: 0.75,
+                    }}
+                >
+                    <ModeDot modeKey={key} />
+                    <Typography
+                        variant="caption"
+                        color="textSecondary"
+                        sx={{
+                            textTransform: "uppercase",
+                            letterSpacing: 0.6,
+                            fontSize: 10,
+                        }}
+                    >
+                        {modeLabel(key)}
+                    </Typography>
+                </Stack>
+                <Box sx={STAT_GRID_SX}>
+                    <StatCell
+                        label="RECORD"
+                        value={`${stats.wins.toString()}W · ${stats.losses.toString()}L`}
+                        fontSize={14}
+                    />
+                    <StatCell
+                        label="FINAL KILLS"
+                        value={stats.fk.toString()}
+                        fontSize={14}
+                    />
+                    <StatCell
+                        label="BEDS BROKEN"
+                        value={stats.bb.toString()}
+                        fontSize={14}
+                    />
+                    <StatCell
+                        label="KILLS / DEATHS"
+                        value={`${stats.k.toString()} / ${stats.d.toString()}`}
+                        fontSize={14}
+                    />
+                </Box>
+            </Box>
+        ))}
+    </Stack>
+);
+
 const GameDetail: React.FC<{ segment: GameSegment; numbering: SegmentGameNumber }> = ({
     segment,
     numbering,
@@ -721,35 +854,33 @@ const GameDetail: React.FC<{ segment: GameSegment; numbering: SegmentGameNumber 
     // derived per segment kind (real game / no-game window / multi-game gap).
     let title: string;
     let context: string;
+    // Set only for a single game, whose one gamemode the header can colour-dot.
+    let modeKey: ModeBreakdownKey | null = null;
     let badge: { label: string; color: string } | null = null;
     let pills: React.ReactNode = null;
-    let items: [string, string][];
+    let items: [string, string][] = [];
+    let modes: readonly ModeEntry[] = [];
 
     if (segment.game === null) {
         const count = inferredGameCount(segment);
         if (count === 0) {
             title = "Segment";
-            context = "No game";
+            context = `No game · ${durationLabel}`;
             items = [
                 ["GAMES", "0"],
                 ["XP", `+${xp.toLocaleString()}`],
                 ["SPAN", durationLabel],
             ];
         } else {
-            const delta = statDelta(segment.start.overall, segment.end.overall);
             title = numberLabel ?? "Games";
-            context = `${count.toString()} game${count === 1 ? "" : "s"}`;
-            items = [
-                ["FINAL KILLS", delta.fk.toString()],
-                ["BEDS BROKEN", delta.bb.toString()],
-                ["KILLS / DEATHS", `${delta.k.toString()} / ${delta.d.toString()}`],
-                ["XP", `+${xp.toLocaleString()}`],
-            ];
+            context = `${count.toString()} game${count === 1 ? "" : "s"} · ${durationLabel} · +${xp.toLocaleString()} XP`;
+            modes = playedModes(segment);
         }
     } else {
         const { game } = segment;
         title = numberLabel ?? "Game";
-        context = getGamemodeLabel(game.gamemode, true);
+        modeKey = game.gamemode;
+        context = `${getGamemodeLabel(game.gamemode, true)} · ${durationLabel}`;
         badge = {
             label: OUTCOME_FULL_LABEL[game.outcome],
             color: outcomeColor(theme, game.outcome),
@@ -828,8 +959,9 @@ const GameDetail: React.FC<{ segment: GameSegment; numbering: SegmentGameNumber 
                     }}
                 >
                     <Typography sx={{ fontWeight: 600 }}>{title}</Typography>
+                    {modeKey !== null && <ModeDot modeKey={modeKey} />}
                     <Typography variant="body2" color="textSecondary">
-                        {`· ${context} · ${durationLabel}`}
+                        {modeKey === null ? `· ${context}` : context}
                     </Typography>
                     {badge !== null && (
                         <Typography
@@ -861,36 +993,15 @@ const GameDetail: React.FC<{ segment: GameSegment; numbering: SegmentGameNumber 
                     </Stack>
                 )}
             </Stack>
-            <Box
-                sx={{
-                    display: "grid",
-                    gridTemplateColumns: "repeat(4, 1fr)",
-                    gap: 1,
-                    maxWidth: 720,
-                    mx: "auto",
-                }}
-            >
-                {items.map(([label, value]) => (
-                    <Box key={label}>
-                        <Typography
-                            variant="caption"
-                            color="textSecondary"
-                            sx={{
-                                textTransform: "uppercase",
-                                letterSpacing: 0.6,
-                                fontSize: 10,
-                            }}
-                        >
-                            {label}
-                        </Typography>
-                        <Typography
-                            sx={{ fontFamily: "monospace", fontSize: 16, mt: 0.5 }}
-                        >
-                            {value}
-                        </Typography>
-                    </Box>
-                ))}
-            </Box>
+            {modes.length > 0 ? (
+                <ModeRows modes={modes} />
+            ) : (
+                <Box sx={{ ...STAT_GRID_SX, maxWidth: 720, mx: "auto" }}>
+                    {items.map(([label, value]) => (
+                        <StatCell key={label} label={label} value={value} />
+                    ))}
+                </Box>
+            )}
         </Box>
     );
 };
@@ -922,6 +1033,39 @@ const ClutchOrCarriedBadge: React.FC<{ game: GameResult }> = ({ game }) => {
     );
 };
 
+// Top highlight for a multi-game tile, split by how those games went: wins
+// green from the left, losses red from the right, and anything neither (a draw,
+// or counters that don't reconcile) as a neutral slice between them.
+const OutcomeSplitBar: React.FC<{ split: OutcomeSplit }> = ({ split }) => {
+    const theme = useTheme();
+    const slices: readonly [GameOutcome, number][] = [
+        ["win", split.winShare],
+        ["draw", split.unknownShare],
+        ["loss", split.lossShare],
+    ];
+    return (
+        <Box
+            sx={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                right: 0,
+                height: 3,
+                display: "flex",
+            }}
+        >
+            {slices.map(([outcome, share]) =>
+                share <= 0 ? null : (
+                    <Box
+                        key={outcome}
+                        sx={{ flexGrow: share, bgcolor: outcomeColor(theme, outcome) }}
+                    />
+                ),
+            )}
+        </Box>
+    );
+};
+
 const GameTile: React.FC<{
     segment: GameSegment;
     numbering: SegmentGameNumber;
@@ -947,6 +1091,13 @@ const GameTile: React.FC<{
             ? `No game was attributed to this window. ${TRACKING_NOTE}`
             : gapTooltip;
         const gamesLabel = count === 1 ? "game" : "games";
+        // A no-game window has nothing to colour or dot, so it keeps the bare
+        // dashed tile it has always had. Gate on the game count rather than on
+        // `outcomeSplit` alone: Hypixel doesn't move its counters atomically,
+        // so a window can show a win with `gamesPlayed` still flat — which
+        // would otherwise paint a full green bar over "no game".
+        const split = noGame ? null : outcomeSplit(segment);
+        const modes = playedModes(segment);
         return (
             <Button
                 onClick={onClick}
@@ -973,6 +1124,7 @@ const GameTile: React.FC<{
                     "&:hover": { bgcolor: alpha(color, 0.07) },
                 }}
             >
+                {split !== null && <OutcomeSplitBar split={split} />}
                 <Stack
                     direction="row"
                     sx={{
@@ -997,14 +1149,13 @@ const GameTile: React.FC<{
                 <Stack
                     direction="row"
                     sx={{
+                        alignItems: "center",
                         gap: 0.75,
                         mt: 1,
                         fontSize: 10,
                     }}
                 >
-                    <Typography variant="caption" color="textSecondary">
-                        ?
-                    </Typography>
+                    <ModeDots modes={modes} />
                     <Typography variant="caption" sx={{ ml: "auto" }}>
                         {`${mins.toString()}m`}
                     </Typography>
@@ -1087,12 +1238,13 @@ const GameTile: React.FC<{
             <Stack
                 direction="row"
                 sx={{
+                    alignItems: "center",
                     gap: 0.75,
                     mt: 1,
                     fontSize: 10,
                 }}
             >
-                <Box sx={{ color: theme.palette.gamemode[game.gamemode] }}>●</Box>
+                <ModeDot modeKey={game.gamemode} />
                 <Typography variant="caption">
                     {getGamemodeLabel(game.gamemode, true)}
                 </Typography>
@@ -1493,24 +1645,12 @@ const ModeDetail: React.FC<{
                     </Typography>
                 </Stack>
                 {items.map(([itemLabel, value]) => (
-                    <Box key={itemLabel}>
-                        <Typography
-                            variant="caption"
-                            color="textSecondary"
-                            sx={{
-                                textTransform: "uppercase",
-                                letterSpacing: 0.6,
-                                fontSize: 10,
-                            }}
-                        >
-                            {itemLabel}
-                        </Typography>
-                        <Typography
-                            sx={{ fontFamily: "monospace", fontSize: 14, mt: 0.5 }}
-                        >
-                            {value}
-                        </Typography>
-                    </Box>
+                    <StatCell
+                        key={itemLabel}
+                        label={itemLabel}
+                        value={value}
+                        fontSize={14}
+                    />
                 ))}
             </Box>
         </Box>
@@ -1534,16 +1674,16 @@ const ModeBreakdown: React.FC<{
     }[] = GAMEMODES.filter((mode) => mode !== "4v4" || data[mode].games > 0).map(
         (mode) => ({
             key: mode,
-            label: getGamemodeLabel(mode, true),
-            color: theme.palette.gamemode[mode],
+            label: modeLabel(mode),
+            color: modeColor(theme, mode),
             stats: data[mode],
         }),
     );
     if (data.other.games > 0) {
         entries.push({
             key: "other",
-            label: "Other",
-            color: theme.palette.textMuted,
+            label: modeLabel("other"),
+            color: modeColor(theme, "other"),
             stats: data.other,
         });
     }

--- a/src/routes/session/-uuid_.detail.ui.test.tsx
+++ b/src/routes/session/-uuid_.detail.ui.test.tsx
@@ -83,6 +83,25 @@ describe("Session detail page", () => {
         await expect.element(screen.getByText("FINAL KILLS")).toBeInTheDocument();
     });
 
+    mswTest("expands a multi-game gap tile into a per-gamemode breakdown", async () => {
+        const { screen } = await renderAppRoute(detailUrl);
+
+        // The mock's last segment covers three games that can't be attributed
+        // individually — a solo win, a fours loss and one in a mode only
+        // `overall` reflects — so it's numbered G4-6 and dotted for all three.
+        const tile = screen.getByText("G4-6").first();
+        await expect.element(tile).toBeInTheDocument();
+        await expect
+            .element(screen.getByLabelText("Modes played: Solo, Fours, Other"))
+            .toBeInTheDocument();
+
+        await tile.click();
+
+        // "RECORD" is the wins/losses column, which only the per-mode rows have.
+        await expect.element(screen.getByText("RECORD").first()).toBeInTheDocument();
+        await expect.element(screen.getByText("Other").first()).toBeInTheDocument();
+    });
+
     mswTest(
         "shows the no-session empty state when session-at returns null",
         async ({ worker }: { readonly worker: SetupWorker }) => {


### PR DESCRIPTION
In the session detail page's game-by-game strip, a tile covering several games that couldn't be attributed individually was the only kind without a top highlight, and it stood in for its gamemode with a question mark.

### Multi-game gap tile

- **Top highlight, split by outcome** — wins green from the left, losses red from the right, and a neutral slice for anything neither. That slice matters: `overall.wins + overall.losses` can trail `gamesPlayed` (draws, or Hypixel counters that don't reconcile), and dropping the difference would make "3 games, 1W 1L" read as an even split. The bar is sized by `max(games, wins + losses)`, and negative counters are clamped, so it can never overflow or invert.
- **Gamemode dots replace the `?`** — one dot per mode played, in the canonical `solo → doubles → threes → fours → 4v4` order with the muted "other" bucket last. Presence is strictly "gamesPlayed advanced", which makes the dots account for exactly the games the segment covers: a Dreams game only moves `overall`, so it lands in "other" rather than going unrepresented. No tooltip; the row is labelled for screen readers.
- A 0-game window is unchanged — no games, so no bar and no dots. The dashed border and the "couldn't be attributed" Help tooltip stay on both.

### Expanded gap detail

Same stats as before, now broken down per gamemode — only the modes actually played — with a wins/losses **record** as the first column:

```
G5-7 · 3 games · 15m · +1,240 XP
● SOLO    1W · 0L    3 finals   2 beds   5 / 2
● FOURS   0W · 1L    1 final    0 beds   3 / 4
● OTHER   0W · 0L    1 final    1 bed    2 / 1
```

XP is segment-wide — experience can't be attributed to a mode — so it moved into the header rather than being split or dashed out per row. The per-game survived / bed-kept pills stay off this view, since they can't be pinned to one game in the stretch.

### Also

- The expanded detail for a single game now reads `G6 ● Fours · 16m WIN`, with the gamemode's dot in place of the separator — matching the dot on its tile.
- `modeBreakdown` now takes any start/end snapshot pair, so one segment reuses the same per-mode logic as the whole-session "By gamemode" panel.
- The MSW mock's `session-at` response gained a three-game gap segment (solo win + fours loss + one non-broken-out mode), so all of this is reachable in dev mode and covered by a UI test.

`pnpm run test:unit` (936) and `pnpm run test:ui` (216) pass, plus new unit tests for `playedModes` and `outcomeSplit` covering draws, over-accounting records and backwards counters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
