### PR TITLE
fix(layout): let main shrink beside the sidebar

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -468,6 +468,13 @@ export const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) =>
                     marginTop: { xs: APP_BAR_HEIGHT_PX, lg: 0 },
                     width: "100%",
                     height: "100%",
+                    // `<main>` is a flex item next to the permanent drawer, so
+                    // its default `min-width: auto` floors it at the content's
+                    // min-content width. Wide content (e.g. the session
+                    // detail game strip) then refuses to give up room for the
+                    // 240px drawer and the whole page scrolls sideways instead
+                    // of the content scrolling inside its own container.
+                    minWidth: 0,
                 }}
             >
                 {/* Wrap the children in a padded box so the bottom spacer

--- a/src/routes/session/-uuid_.detail.ui.test.tsx
+++ b/src/routes/session/-uuid_.detail.ui.test.tsx
@@ -1,8 +1,10 @@
 import { http, HttpResponse } from "msw";
 import type { SetupWorker } from "msw/browser";
 import { describe, expect } from "vitest";
+import { page } from "vitest/browser";
 
-import { USERS } from "#mocks/data.ts";
+import { makePlayerDataPIT, makeSession, USERS } from "#mocks/data.ts";
+import type { APISessionAtResponse } from "#queries/sessionAt.ts";
 import { mswTest } from "#test/msw-test.ts";
 import { renderAppRoute } from "#test/render.tsx";
 
@@ -116,6 +118,77 @@ describe("Session detail page", () => {
             await expect
                 .element(screen.getByText("No session yet"))
                 .toBeInTheDocument();
+        },
+    );
+
+    mswTest(
+        "long sessions scroll the game strip instead of the page",
+        async ({ worker }: { readonly worker: SetupWorker }) => {
+            const { uuid } = USERS.player1;
+            const start = new Date(date);
+            // Enough games that the strip's `minmax(120px, 1fr)` columns exceed
+            // the width left over next to the desktop sidebar.
+            const gameCount = 12;
+            const pits = Array.from({ length: gameCount + 1 }, (_, index) =>
+                makePlayerDataPIT(
+                    uuid,
+                    new Date(start.getTime() + index * 10 * 60 * 1000).toISOString(),
+                    index + 1,
+                ),
+            );
+
+            worker.use(
+                http.post("http://localhost:5173/flashlight/v1/session-at", () => {
+                    const response: APISessionAtResponse = {
+                        session: makeSession(
+                            uuid,
+                            pits[0].queriedAt,
+                            pits[gameCount].queriedAt,
+                        ),
+                        games: Array.from({ length: gameCount }, (_, index) => ({
+                            start: pits[index],
+                            end: pits[index + 1],
+                            game: {
+                                gamemode: "doubles",
+                                outcome: "win",
+                                finalKills: 5,
+                                finalDeath: true,
+                                bedsBroken: 1,
+                                bedLost: false,
+                                kills: 12,
+                                deaths: 4,
+                                experience: 2400,
+                            },
+                        })),
+                    };
+                    return HttpResponse.json(response);
+                }),
+            );
+
+            // Wide enough for the permanent sidebar to be shown.
+            await page.viewport(1280, 720);
+            const { screen } = await renderAppRoute(detailUrl);
+
+            const tile = screen.getByText("G1").first();
+            await expect.element(tile).toBeInTheDocument();
+
+            // The page itself must not scroll sideways ...
+            const { documentElement } = document;
+            await expect
+                .poll(() => documentElement.scrollWidth - documentElement.clientWidth)
+                .toBe(0);
+
+            // ... the strip holding the tiles does, so the later games stay
+            // reachable rather than being clipped away. It is the only
+            // horizontally scrollable container inside `<main>` (the sidebar
+            // has one too, hence the scoping).
+            const strip = [
+                ...(document.querySelector("main")?.querySelectorAll("div") ?? []),
+            ].find(
+                (element) => globalThis.getComputedStyle(element).overflowX === "auto",
+            );
+            expect(strip).toBeDefined();
+            expect(strip?.scrollWidth).toBeGreaterThan(strip?.clientWidth ?? 0);
         },
     );
 });


### PR DESCRIPTION
## Problem

At viewport widths where the permanent sidebar shows (`lg` and up), the session detail page picked up a horizontal scrollbar — but only for sessions with enough games. Short sessions (~4 games) were fine, longer ones (9+) were not.

Example: https://prismoverlay.com/session/6bc1dd0f-f351-4c3d-b6cc-262e55b6e7aa/detail?date=%222026-08-08T03%3A39%3A02.967Z%22

## Cause

`<main>` in `Layout.tsx` is a flex item sitting next to the 240px permanent `Drawer`. It had `width: 100%` but no `min-width`, so the flex algorithm floored it at its content's **min-content width** (`min-width: auto` is the default for flex items).

The game-by-game strip lays its tiles out as `repeat(N, minmax(120px, 1fr))`, so its min-content width grows by 120px per game. Past roughly 8 games that floor exceeds the space left over next to the drawer, `<main>` refuses to shrink, and the document scrolls sideways — instead of the strip scrolling inside its own `overflow-x: auto` container, which is what it was written to do.

At widths below `lg` the drawer is hidden, nothing needs to shrink, and the strip scrolls correctly — which is why the bug only showed up once the sidebar appeared.

## Fix

`min-width: 0` on `<main>` so it can yield the drawer's 240px. The strip then scrolls itself as intended, and no tiles are clipped. This is a layout-wide fix, so any future wide content is covered too — no per-page tile-count math needed.

## Test

Added a UI regression test that mocks a 12-game session at a 1280px viewport and asserts both halves of the contract:

- `documentElement.scrollWidth === clientWidth` (the page does not scroll sideways)
- the strip's `scrollWidth > clientWidth` (the later games stay reachable rather than being clipped)

Without the fix it fails with a 240px overflow — exactly the drawer's width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
